### PR TITLE
Made ghosts move instantly

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -26,7 +26,7 @@
 
 		// Otherwise jump
 		else
-			following = null
+			unfollow()
 			loc = get_turf(A)
 
 		return 1

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -2,7 +2,7 @@
 	return
 
 /mob/dead/observer/on_mob_jump()
-	following = null
+	unfollow()
 
 /client/proc/Jump(var/area/A in return_sorted_areas())
 	set name = "Jump to Area"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -354,6 +354,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		following = target
 		loc = target.loc
 		src << "\blue Now following [target]"
+		spawn(0) //Backup
+			while(target && following == target && client)
+				var/turf/T = get_turf(target)
+				if(!T)
+					break
+				// To stop the ghost flickering.
+				if(loc != T)
+					loc = T
+				sleep(15)
 
 /mob/dead/observer/verb/jumptomob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -163,9 +163,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
 	return
 
+/mob/dead/observer/proc/unfollow()
+	following?.followers -= src
+	following = null
 
 /mob/dead/observer/Move(NewLoc, direct)
-	following = null
+	unfollow()
 	dir = direct
 	if(NewLoc)
 		loc = NewLoc
@@ -274,7 +277,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		usr << "No area available."
 
 	usr.loc = pick(L)
-	following = null
+	unfollow()
 
 /mob/dead/observer/verb/follow()
 	set category = "Ghost"
@@ -331,22 +334,26 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/mob/target = mobs[input]
 	ManualFollow(target)
 
+/atom/movable
+	var/list/mob/dead/observer/followers = list()
+
+/atom/movable/Moved()
+	..()
+	
+	if(followers.len)
+		for(var/_F in followers)
+			var/mob/dead/observer/F = _F //Read this was faster than var/typepath/F in list
+			F.loc = loc
+
 // This is the ghost's follow verb with an argument
 /mob/dead/observer/proc/ManualFollow(var/atom/movable/target)
 	if(target && target != src)
 		if(following && following == target)
 			return
+		target.followers += src
 		following = target
+		loc = target.loc
 		src << "\blue Now following [target]"
-		spawn(0)
-			while(target && following == target && client)
-				var/turf/T = get_turf(target)
-				if(!T)
-					break
-				// To stop the ghost flickering.
-				if(loc != T)
-					loc = T
-				sleep(15)
 
 /mob/dead/observer/verb/jumptomob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"
@@ -371,7 +378,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 			if(T && isturf(T))	//Make sure the turf exists, then move the source to that destination.
 				A.loc = T
-				following = null
+				unfollow()
 			else
 				A << "This mob is not located in the game world."
 /*


### PR DESCRIPTION
Playing as an observer is annoying in CM because it only updates your position once every 1.5s. With this change, your position will update as the movable atom moves. There's no components in the CM codebase so the code is a bit gross.