### PR TITLE
Changed external default links

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -181,13 +181,13 @@ GUEST_BAN
 #SERVER server.net:port
 
 ## forum address
-FORUMURL https://cm-ss13.com/
+FORUMURL https://tgstation13.org/phpBB/
 
 ## Wiki address
-WIKIURL https://cm-ss13/wiki/
+WIKIURL https://tgstation13.org/wiki
 
 ## Rules address
-RULESURL https://cm-ss13.com/viewtopic.php?f=57&t=5094
+RULESURL https://tgstation13.org/wiki/Rules/DMCA_Addendum
 
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 BANAPPEALS https://cm-ss13.com/viewforum.php?f=76

--- a/config/config.txt
+++ b/config/config.txt
@@ -187,7 +187,7 @@ FORUMURL https://tgstation13.org/phpBB/
 WIKIURL https://tgstation13.org/wiki
 
 ## Rules address
-RULESURL https://tgstation13.org/wiki/Rules/DMCA_Addendum
+RULESURL https://tgstation13.org/wiki/DMCA_Rules
 
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 BANAPPEALS https://cm-ss13.com/viewforum.php?f=76


### PR DESCRIPTION
The links(forum, wiki and rules) defined in the configuration file was pointing to colonial marines web. Now by deafult, it points tg station.