### PR TITLE
Makes the suicide rejection message friendlier

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -21,7 +21,8 @@
 
 	if(!permitted)
 		message_admins("[ckey] has tried to suicide, but they were not permitted due to not being antagonist as human.", 1)
-		src << "Suicide is easy! Just attack yourself with a gun, while targeting your mouth. Please don't do so flippantly!"
+		src << "Suicide is easy! Just attack yourself with a gun, while targeting your mouth."
+		src << "Please don't do so flippantly! If you want to just leave the round, enter a hypersleep bed."
 		return
 
 	if (suiciding)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -21,7 +21,7 @@
 
 	if(!permitted)
 		message_admins("[ckey] has tried to suicide, but they were not permitted due to not being antagonist as human.", 1)
-		src << "No. Adminhelp if there is a legitimate reason."
+		src << "Suicide is easy! Just attack yourself with a gun, while targeting your mouth. Please don't do so flippantly!"
 		return
 
 	if (suiciding)


### PR DESCRIPTION
Mechanically, changes nothing about the suicide verb.

BUT, my gut feeling is that a lot of the desire to change the mechanic stems from... powergaming nerds.

BUT some of it probably stems from the message making it sound like suicide isn't permitted ever-ever-ever and will get you the bwoink for goodness, and there _are_ plenty of situations in your average round where suicide is a RP-reasonable course of action -- it's not even remotely difficult to imagine a character who would off themselves after breaking out of a nest, for example, and that sort of thing probably shouldn't be discouraged.