### PR TITLE
Reallows slipping 

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1418,7 +1418,7 @@
 	T.add_vomit_floor(src)
 
 /mob/living/carbon/human/slip(slip_source_name, stun_level, weaken_level, run_only, override_noslip, slide_steps)
-	if(shoes && !override_noslip) && (shoes.flags_inventory & NOSLIPPING)) // Slipping is saved!
+	if((shoes && !override_noslip) && (shoes.flags_inventory & NOSLIPPING)) // Slipping is saved!
 		return FALSE
 	. = ..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1418,7 +1418,7 @@
 	T.add_vomit_floor(src)
 
 /mob/living/carbon/human/slip(slip_source_name, stun_level, weaken_level, run_only, override_noslip, slide_steps)
-	if(shoes && !override_noslip) // && (shoes.flags_inventory & NOSLIPPING)) // no more slipping if you have shoes on. -spookydonut
+	if(shoes && !override_noslip) && (shoes.flags_inventory & NOSLIPPING)) // no more slipping if you have shoes on. -spookydonut
 		return FALSE
 	. = ..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1418,7 +1418,7 @@
 	T.add_vomit_floor(src)
 
 /mob/living/carbon/human/slip(slip_source_name, stun_level, weaken_level, run_only, override_noslip, slide_steps)
-	if(shoes && !override_noslip) && (shoes.flags_inventory & NOSLIPPING)) // no more slipping if you have shoes on. -spookydonut
+	if(shoes && !override_noslip) && (shoes.flags_inventory & NOSLIPPING)) // Slipping is saved!
 		return FALSE
 	. = ..()
 


### PR DESCRIPTION
Slipping was originally disabled on CM due to roundstart shenanigans that didn't fit their targeted roleplay environment, due to the lower RP this server is shooting for i feel slipping should be allowed, and if people get griefy with it then that can be handled by the admins.