### PR TITLE
Removes a CM closed source relic.

### DIFF
--- a/code/controllers/ProcessScheduler/DO NOT TOUCH THESE FILES.txt
+++ b/code/controllers/ProcessScheduler/DO NOT TOUCH THESE FILES.txt
@@ -1,3 +1,0 @@
-This is a licensed library distributed by Goonstation.
-DO NOT MAKE ANY CHANGES TO THESE CODE FILES OR IT WILL BREAK THE LICENSING.
-Github: https://github.com/goonstation/ProcessScheduler


### PR DESCRIPTION
This file is no longer needed considering this repo is currently licensed under AGPLV3 so this file is compatible.