### PR TITLE
Refactor __DEFINES, __HELPERS, _onclick for conformity to style guide and legibility

### DIFF
--- a/code/__DEFINES/__game.dm
+++ b/code/__DEFINES/__game.dm
@@ -74,7 +74,6 @@ These are used with cdel (clean delete). For example, cdel(atom, TA_REVIVE_ME) w
 //Object specific defines
 #define CANDLE_LUM 3 //For how bright candles are
 
-
 //Preference toggles//
 //toggles_sound
 #define SOUND_ADMINHELP	1
@@ -101,7 +100,6 @@ These are used with cdel (clean delete). For example, cdel(atom, TA_REVIVE_ME) w
 #define TOGGLES_CHAT_DEFAULT (CHAT_OOC|CHAT_DEAD|CHAT_GHOSTEARS|CHAT_GHOSTSIGHT|CHAT_PRAYER|CHAT_RADIO|CHAT_ATTACKLOGS|CHAT_LOOC|CHAT_GHOSTHIVEMIND)
 
 #define TOGGLES_SOUND_DEFAULT (SOUND_ADMINHELP|SOUND_MIDI|SOUND_AMBIENCE|SOUND_LOBBY)
-
 
 /*
 	Shuttles
@@ -164,7 +162,6 @@ These are used with cdel (clean delete). For example, cdel(atom, TA_REVIVE_ME) w
 
 #define ROUNDSTART_LOGOUT_REPORT_TIME 6000 //Amount of time (in deciseconds) after the rounds starts, that the player disconnect report is issued.
 
-
 //=================================================
 
 //computer3 error codes, move lower in the file when it passes dev -Sayu
@@ -185,7 +182,6 @@ var/list/accessable_z_levels = list("1" = 10, "3" = 10, "4" = 10, "5" = 70)
 //Go away Urist, I'm restoring this to the longer list. ~Errorage
 
 #define TRANSITIONEDGE	3 //Distance from edge to move to another z-level
-
 
 var/static/list/scarySounds = list('sound/weapons/thudswoosh.ogg','sound/weapons/Taser.ogg','sound/weapons/armbomb.ogg','sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg','sound/voice/hiss5.ogg','sound/voice/hiss6.ogg','sound/effects/Glassbr1.ogg','sound/effects/Glassbr2.ogg','sound/effects/Glassbr3.ogg','sound/items/Welder.ogg','sound/items/Welder2.ogg','sound/machines/airlock.ogg','sound/effects/clownstep1.ogg','sound/effects/clownstep2.ogg')
 //Flags for zone sleeping

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -20,7 +20,6 @@
 #define MAX_HIGH_PRESSURE_DAMAGE 4	//This used to be 20... I got this much random rage for some retarded decision by polymorph?! Polymorph now lies in a pool of blood with a katana jammed in his spleen. ~Errorage --PS: The katana did less than 20 damage to him :(
 #define LOW_PRESSURE_DAMAGE 2 	//The amounb of damage someone takes when in a low pressure area (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
 
-
 #define R_IDEAL_GAS_EQUATION	8.31 //kPa*L/(K*mol)
 #define ONE_ATMOSPHERE		101.325	//kPa
 #define IDEAL_GAS_ENTROPY_CONSTANT 	1164	//(mol^3 * s^3) / (kg^3 * L). Equal to (4*pi/(avrogadro's number * planck's constant)^2)^(3/2) / (avrogadro's number * 1000 Liters per m^3).
@@ -79,8 +78,6 @@
 	//Must be between 0 and 1. Values closer to 1 equalize temperature faster
 	//Should not exceed 0.4 else strange heat flow occur
 
-
-
 // Fire Damage
 #define CARBON_LIFEFORM_FIRE_RESISTANCE 200+T0C
 #define CARBON_LIFEFORM_FIRE_DAMAGE		4
@@ -105,8 +102,6 @@
 #define GAS_TYPE_PHORON		"phoron"
 #define GAS_TYPE_CO2		"carbon dioxyde"
 
-
-
 //Used to be used by FEA
 //var/turf/open/space/Space_Tile = locate(/turf/open/space) // A space tile to reference when atmos wants to remove excess heat.
 
@@ -120,7 +115,6 @@
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
 var/MAX_EXPLOSION_RANGE = 14
 //#define MAX_EXPLOSION_RANGE		14					// Defaults to 12 (was 8) -- TLE
-
 
 #define NORMPIPERATE 30					//pipe-insulation rate divisor
 #define HEATPIPERATE 8					//heat-exch pipe insulation

--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -1,6 +1,5 @@
 //FLAGS BITMASK
 
-
 //turf-only flags
 #define NOJAUNT		1
 
@@ -43,7 +42,6 @@
 
 //==========================================================================================
 
-
 //flags_inv_hide
 //Bit flags for the flags_inv_hide variable, which determine when a piece of clothing hides another. IE a helmet hiding glasses.
 
@@ -59,7 +57,6 @@
 #define HIDEALLHAIR		512		// temporarily removes the user's hair, facial and otherwise.
 #define HIDETAIL 		1024
 #define HIDEFACE		2056	//Dictates whether we appear as unknown.
-
 
 //==========================================================================================
 
@@ -85,10 +82,6 @@
 #define BLOCKSHARPOBJ 	128  //From /tg: prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body.
 #define NOPRESSUREDMAGE 256 //This flag is used on the flags variable for SUIT and HEAD items which stop pressure damage.
 //SUITS AND HELMETS====================================================================================
-
-
-
-
 
 //===========================================================================================
 //Marine armor only, use for flags_marine_armor.

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -20,10 +20,8 @@
 #define ATMOS_PIPE_SUPPLY_LAYER 2.39
 #define ATMOS_PIPE_LAYER 2.4
 
-
 #define WIRE_LAYER 2.44
 #define WIRE_TERMINAL_LAYER 2.45
-
 
 #define UNDERFLOOR_OBJ_LAYER 2.5 //bluespace beacon, navigation beacon, etc
 
@@ -65,7 +63,6 @@
 #define DOOR_CLOSED_LAYER 3.1	//Above most items if closed
 #define FIREDOOR_CLOSED_LAYER 3.189		//Right under poddoors
 #define PODDOOR_CLOSED_LAYER 3.19	//Above doors which are at 3.1
-
 
 #define WINDOW_LAYER 3.2 //above closed doors
 

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -1,14 +1,12 @@
 
 //for all defines that doesn't fit in any other file.
 
-
 //dirt type for each turf types.
 
 #define NO_DIRT				0
 #define DIRT_TYPE_GROUND	1
 #define DIRT_TYPE_MARS		2
 #define DIRT_TYPE_SNOW		3
-
 
 //wet floors
 

--- a/code/__DEFINES/mob_hud.dm
+++ b/code/__DEFINES/mob_hud.dm
@@ -18,7 +18,6 @@
 #define PHEROMONE_HUD		"14" //indicates which pheromone is active on a xeno.
 #define QUEEN_OVERWATCH_HUD	"15" //indicates which xeno the queen is overwatching.
 
-
 //data HUD (medhud, sechud) defines
 #define MOB_HUD_SECURITY_BASIC		1
 #define MOB_HUD_SECURITY_ADVANCED	2
@@ -28,4 +27,3 @@
 #define MOB_HUD_XENO_INFECTION		6
 #define MOB_HUD_XENO_STATUS			7
 #define MOB_HUD_SQUAD				8
-

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -5,7 +5,6 @@
 #define BORGTHERM 2
 #define BORGXRAY  4
 
-
 /*
 	reagents defines
 */
@@ -37,7 +36,6 @@
 #define PAIN_REDUCTION_HEAVY		-50 //paracetamol
 #define PAIN_REDUCTION_VERY_HEAVY	-80 //tramadol
 #define PAIN_REDUCTION_FULL			-200 //oxycodone, neuraline
-
 
 //=================================================
 /*
@@ -221,7 +219,6 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define LIMB_AMPUTATED 128 //limb was amputated cleanly or destroyed limb was cleaned up, thus causing no pain
 #define LIMB_REPAIRED 256 //we just repaired the bone, stops the gelling after setting
 
-
 /////////////////MOVE DEFINES//////////////////////
 #define MOVE_INTENT_WALK        1
 #define MOVE_INTENT_RUN         2
@@ -229,7 +226,6 @@ var/list/global_mutations = list() // list of hidden mutation things
 
 #define ORGAN_ASSISTED	1
 #define ORGAN_ROBOT		2
-
 
 ///////////////SURGERY DEFINES///////////////
 #define SPECIAL_SURGERY_INVALID	"special_surgery_invalid"
@@ -371,7 +367,6 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define MOB_SIZE_XENO			2
 #define MOB_SIZE_BIG		3
 
-
 //defines for the busy icons when the mob does something that takes time using do_after proc
 #define BUSY_ICON_GENERIC	1
 #define BUSY_ICON_MEDICAL	2
@@ -379,14 +374,12 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define BUSY_ICON_FRIENDLY	4
 #define BUSY_ICON_HOSTILE	5
 
-
 //defins for datum/hud
 
 #define HUD_STYLE_STANDARD	1
 #define HUD_STYLE_REDUCED	2
 #define HUD_STYLE_NOHUD		3
 #define HUD_VERSIONS		3
-
 
 //Blood levels
 #define BLOOD_VOLUME_MAXIMUM	600
@@ -397,7 +390,6 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define BLOOD_VOLUME_SURVIVE	122
 
 #define HUMAN_MAX_PALENESS	30 //this is added to human skin tone to get value of pale_max variable
-
 
 //diseases
 
@@ -411,7 +403,6 @@ var/list/global_mutations = list() // list of hidden mutation things
 
 #define SCANNER 1
 #define PANDEMIC 2
-
 
 //forcesay types
 #define SUDDEN 0

--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -21,7 +21,6 @@
 #define FLAGS_SELF_DESTRUCT_DENY 2
 //=================================================
 
-
 #define IS_MODE_COMPILED(MODE) (ispath(text2path("/datum/game_mode/"+(MODE))))
 
 #define MODE_INFESTATION		1
@@ -37,7 +36,6 @@
 #define BE_SURVIVOR		4
 #define BE_RESPONDER	8
 #define BE_PREDATOR		16
-
 
 #define BE_REV        32
 #define BE_TRAITOR    64
@@ -150,5 +148,4 @@ var/list/be_special_flags = list(
 #define WHITELIST_ARCTURIAN			64
 #define WHITELIST_ALL				(WHITELIST_YAUTJA_UNBLOODED|WHITELIST_YAUTJA_BLOODED|WHITELIST_YAUTJA_ELITE|WHITELIST_YAUTJA_ELDER|WHITELIST_COMMANDER|WHITELIST_SYNTHETIC|WHITELIST_ARCTURIAN)
 //=================================================
-
 

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -103,7 +103,6 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define STASIS_IN_BAG 		1
 #define STASIS_IN_CRYO_CELL 2
 
-
 // Diagonal movement for movable atoms
 #define FIRST_DIAG_STEP 	1
 #define SECOND_DIAG_STEP 	2
@@ -115,15 +114,12 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define SHUTTLE_COOLING_FACTOR_RECHARGE 0.5
 #define SHUTTLE_FUEL_ENHANCE_FACTOR_TRAVEL 0.75
 
-
 //sharp item defines
 #define IS_SHARP_ITEM_SIMPLE 		1 //not easily usable to cut or slice. e.g. shard, wirecutters, spear
 #define IS_SHARP_ITEM_ACCURATE		2 //knife, scalpel
 #define IS_SHARP_ITEM_BIG			3 //fireaxe, hatchet, energy sword
 
-
 //pry capable item defines
 #define IS_PRY_CAPABLE_SIMPLE		1
 #define IS_PRY_CAPABLE_CROWBAR		2 //actual crowbar
 #define IS_PRY_CAPABLE_FORCE		3 //can force open even powered airlocks
-

--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -1,6 +1,4 @@
-
 //skill defines
-
 
 //firearms skill (general knowledge of guns) (hidden skill)
 //increase or decrase accuracy, recoil, and firing delay of rifles and smgs.
@@ -33,8 +31,6 @@
 #define SKILL_HEAVY_WEAPONS_DEFAULT 	0	//marines
 #define SKILL_HEAVY_WEAPONS_TRAINED		1	//special training
 
-
-
 //smartgun skill
 //increase or decrase accuracy, recoil, and firing delay for smartgun, and whether we can use smartguns at all.
 #define SKILL_SMART_DEFAULT 		-4 //big negative so the effects are far worse than pistol/rifle untrained
@@ -42,8 +38,6 @@
 #define SKILL_SMART_TRAINED			0 //default for smartgunner
 #define SKILL_SMART_EXPERT			1
 #define SKILL_SMART_MASTER			2
-
-
 
 //spec_weapons skill
 //hidden. who can and can't use specialist weapons
@@ -55,17 +49,12 @@
 #define SKILL_SPEC_PYRO			5
 #define SKILL_SPEC_TRAINED		6 //can use all specialist gear
 
-
-
 //construction skill
 #define SKILL_CONSTRUCTION_DEFAULT	0
 #define SKILL_CONSTRUCTION_METAL 	1	//metal barricade construction (CT)
 #define SKILL_CONSTRUCTION_PLASTEEL 2	//plasteel barricade,(Req)(combat engi)
 #define SKILL_CONSTRUCTION_ADVANCED	3	//windows and girder construction
 #define SKILL_CONSTRUCTION_MASTER	4	//building machine&computer frames (MT, CE)
-
-
-
 
 // engineer skill
 #define SKILL_ENGINEER_DEFAULT	0
@@ -75,7 +64,6 @@
 #define SKILL_ENGINEER_MT 		4	//Telecomms fixing, faster engine fixing (MT)
 //higher levels give faster Almayer engine repair.
 
-
 //medical skill
 #define SKILL_MEDICAL_DEFAULT	0
 #define SKILL_MEDICAL_CHEM		1 // recognizing chemicals, using autoinjectors & hyposprays with any chemicals (SL)
@@ -84,22 +72,16 @@
 #define SKILL_MEDICAL_CMO		4
 //higher levels means faster syringe use and better defibrillation
 
-
 //surgery skill
 #define SKILL_SURGERY_DEFAULT	0
 #define SKILL_SURGERY_TRAINED	1 //can do surgery (Doctor)
 #define SKILL_SURGERY_EXPERT	2 //faster surgery (CMO)
 //higher levels means faster surgery.
 
-
-
-
-
 //police skill, hidden
 #define SKILL_POLICE_DEFAULT 	0
 #define SKILL_POLICE_FLASH 		1 //flash use (CE, CMO, any officer starting with a flash)
 #define SKILL_POLICE_MP 		2 //all police gear use, can strip someone's clothes simultaneously (MP)
-
 
 //cqc skill
 //higher disarm chance on humans(+5% per level)
@@ -110,7 +92,6 @@
 #define SKILL_CQC_MP		2 //no risk of accidental weapon discharge upon disarming (MP)
 #define SKILL_CQC_MASTER	5
 
-
 //powerloader skill
 //hidden
 //proficiency with powerloader, changes powerloader speed.
@@ -120,14 +101,12 @@
 #define SKILL_POWERLOADER_PRO		3 //MT
 #define SKILL_POWERLOADER_MASTER	4 //CE
 
-
 //leadership skill
 #define SKILL_LEAD_NOVICE			0 //Anyone but the above. Using SL items is possible but painfully slow
 #define SKILL_LEAD_BEGINNER			1 //All non-Standard Marines
 #define SKILL_LEAD_TRAINED			2 //SL
 #define SKILL_LEAD_EXPERT			3 //SOs
 #define SKILL_LEAD_MASTER			4 //XO, CO
-
 
 //melee_weapons skill
 //buff to melee weapon attack damage(+30% dmg per level)
@@ -136,15 +115,11 @@
 #define SKILL_MELEE_TRAINED		1
 #define SKILL_MELEE_SUPER		2
 
-
 //pilot skill, hidden
 #define SKILL_PILOT_DEFAULT		0
 #define SKILL_PILOT_TRAINED		1 //Pilot
 
-
 //endurance skill TBD
-
-
 
 ////////////////////////////////////////////////
 
@@ -157,7 +132,6 @@
 #define GUN_SKILL_HEAVY_WEAPONS	"heavy_weapons"
 #define GUN_SKILL_SMARTGUN		"smartgun"
 #define GUN_SKILL_SPEC			"spec_weapons"
-
 
 //multitile vehicle skills
 #define SKILL_LARGE_VEHICLE_DEFAULT 0

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -26,9 +26,7 @@
 	return 0 //not in range and not telekinetic
 
 // Like view but bypasses luminosity check
-
 /proc/hear(var/range, var/atom/source)
-
 	var/lum = source.luminosity
 	source.luminosity = 6
 
@@ -36,9 +34,6 @@
 	source.luminosity = lum
 
 	return heard
-
-
-
 
 //Magic constants obtained by using linear regression on right-angled triangles of sides 0<x<1, 0<y<1
 //They should approximate pythagoras theorem well enough for our needs.
@@ -53,7 +48,6 @@
 #undef k2
 
 /proc/circlerange(center=usr,radius=3)
-
 	var/turf/centerturf = get_turf(center)
 	var/list/turfs = new/list()
 	var/rsq = radius * (radius+0.5)
@@ -68,7 +62,6 @@
 	return turfs
 
 /proc/circleview(center=usr,radius=3)
-
 	var/turf/centerturf = get_turf(center)
 	var/list/atoms = new/list()
 	var/rsq = radius * (radius+0.5)
@@ -99,7 +92,6 @@
 	return dist
 
 /proc/circlerangeturfs(center=usr,radius=3)
-
 	var/turf/centerturf = get_turf(center)
 	var/list/turfs = new/list()
 	var/rsq = radius * (radius+0.5)
@@ -111,8 +103,7 @@
 			turfs += T
 	return turfs
 
-/proc/circleviewturfs(center=usr,radius=3)		//Is there even a diffrence between this proc and circlerangeturfs()?
-
+/proc/circleviewturfs(center=usr,radius=3)	//Is there even a difference between this proc and circlerangeturfs()?
 	var/turf/centerturf = get_turf(center)
 	var/list/turfs = new/list()
 	var/rsq = radius * (radius+0.5)
@@ -124,16 +115,10 @@
 			turfs += T
 	return turfs
 
-
-
-//var/debug_mob = 0
-
 // Will recursively loop through an atom's contents and check for mobs, then it will loop through every atom in that atom's contents.
 // It will keep doing this until it checks every content possible. This will fix any problems with mobs, that are inside objects,
 // being unable to hear people due to being in a box within a bag.
-
 /proc/recursive_mob_check(var/atom/O,  var/list/L = list(), var/recursion_limit = 3, var/client_check = 1, var/sight_check = 1, var/include_radio = 1)
-
 	//debug_mob += O.contents.len
 	if(!recursion_limit)
 		return L
@@ -161,9 +146,8 @@
 // The old system would loop through lists for a total of 5000 per function call, in an empty server.
 // This new system will loop at around 1000 in an empty server.
 
+// Returns a list of mobs in range of R from source. Used in radio and say code.
 /proc/get_mobs_in_view(var/R, var/atom/source)
-	// Returns a list of mobs in range of R from source. Used in radio and say code.
-
 	var/turf/T = get_turf(source)
 	var/list/hear = list()
 
@@ -186,12 +170,10 @@
 
 	return hear
 
-
 /proc/get_mobs_in_radio_ranges(var/list/obj/item/device/radio/radios)
-
 	set background = 1
-
 	. = list()
+	
 	// Returns a list of mobs who can hear any of the radios given in @radios
 	var/list/speaker_coverage = list()
 	for(var/obj/item/device/radio/R in radios)
@@ -211,7 +193,6 @@
 				for(var/turf/T in hear(R.canhear_range,speaker))
 					speaker_coverage[T] = T
 
-
 	// Try to find all the players who can hear the message
 	for(var/i = 1; i <= player_list.len; i++)
 		var/mob/M = player_list[i]
@@ -224,40 +205,38 @@
 	return .
 
 #define SIGN(X) ((X<0)?-1:1)
-
-proc
-	inLineOfSight(X1,Y1,X2,Y2,Z=1,PX1=16.5,PY1=16.5,PX2=16.5,PY2=16.5)
-		var/turf/T
-		if(X1==X2)
-			if(Y1==Y2)
-				return 1 //Light cannot be blocked on same tile
-			else
-				var/s = SIGN(Y2-Y1)
-				Y1+=s
-				while(Y1!=Y2)
-					T=locate(X1,Y1,Z)
-					if(T.opacity)
-						return 0
-					Y1+=s
+/proc/inLineOfSight(X1,Y1,X2,Y2,Z=1,PX1=16.5,PY1=16.5,PX2=16.5,PY2=16.5)
+	var/turf/T
+	if(X1==X2)
+		if(Y1==Y2)
+			return 1 //Light cannot be blocked on same tile
 		else
-			var/m=(32*(Y2-Y1)+(PY2-PY1))/(32*(X2-X1)+(PX2-PX1))
-			var/b=(Y1+PY1/32-0.015625)-m*(X1+PX1/32-0.015625) //In tiles
-			var/signX = SIGN(X2-X1)
-			var/signY = SIGN(Y2-Y1)
-			if(X1<X2)
-				b+=m
-			while(X1!=X2 || Y1!=Y2)
-				if(round(m*X1+b-Y1))
-					Y1+=signY //Line exits tile vertically
-				else
-					X1+=signX //Line exits tile horizontally
+			var/s = SIGN(Y2-Y1)
+			Y1+=s
+			while(Y1!=Y2)
 				T=locate(X1,Y1,Z)
 				if(T.opacity)
 					return 0
-		return 1
+				Y1+=s
+	else
+		var/m=(32*(Y2-Y1)+(PY2-PY1))/(32*(X2-X1)+(PX2-PX1))
+		var/b=(Y1+PY1/32-0.015625)-m*(X1+PX1/32-0.015625) //In tiles
+		var/signX = SIGN(X2-X1)
+		var/signY = SIGN(Y2-Y1)
+		if(X1<X2)
+			b+=m
+		while(X1!=X2 || Y1!=Y2)
+			if(round(m*X1+b-Y1))
+				Y1+=signY //Line exits tile vertically
+			else
+				X1+=signX //Line exits tile horizontally
+			T=locate(X1,Y1,Z)
+			if(T.opacity)
+				return 0
+	return 1
 #undef SIGN
 
-proc/isInSight(var/atom/A, var/atom/B)
+/proc/isInSight(var/atom/A, var/atom/B)
 	var/turf/Aturf = get_turf(A)
 	var/turf/Bturf = get_turf(B)
 
@@ -270,8 +249,8 @@ proc/isInSight(var/atom/A, var/atom/B)
 	else
 		return 0
 
+//returns only NORTH, SOUTH, EAST, or WEST
 /proc/get_cardinal_step_away(atom/start, atom/finish) //returns the position of a step from start away from finish, in one of the cardinal directions
-	//returns only NORTH, SOUTH, EAST, or WEST
 	var/dx = finish.x - start.x
 	var/dy = finish.y - start.y
 	if(abs(dy) > abs (dx)) //slope is above 1:1 (move horizontally in a tie)
@@ -291,10 +270,8 @@ proc/isInSight(var/atom/A, var/atom/B)
 			return M
 	return null
 
-
 // Will return a list of active candidates. It increases the buffer 5 times until it finds a candidate which is active within the buffer.
 /proc/get_active_candidates(var/buffer = 1)
-
 	var/list/candidates = list() //List of candidate KEYS to assume control of the new larva ~Carn
 	var/i = 0
 	while(candidates.len <= 0 && i < 5)
@@ -345,7 +322,7 @@ proc/isInSight(var/atom/A, var/atom/B)
 			for(var/client/C in group)
 				C.screen -= O
 
-datum/projectile_data
+/datum/projectile_data
 	var/src_x
 	var/src_y
 	var/time
@@ -366,12 +343,10 @@ datum/projectile_data
 	src.dest_x = dest_x
 	src.dest_y = dest_y
 
+// returns the destination (Vx,y) that a projectile shot at [src_x], [src_y], with an angle of [angle],
+// rotated at [rotation] and with the power of [power]
+// Thanks to VistaPOWA for this function
 /proc/projectile_trajectory(var/src_x, var/src_y, var/rotation, var/angle, var/power)
-
-	// returns the destination (Vx,y) that a projectile shot at [src_x], [src_y], with an angle of [angle],
-	// rotated at [rotation] and with the power of [power]
-	// Thanks to VistaPOWA for this function
-
 	var/power_x = power * cos(angle)
 	var/power_y = power * sin(angle)
 	var/time = 2* power_y / 10 //10 = g
@@ -416,11 +391,8 @@ datum/projectile_data
 	var/b = mixOneColor(weights, blues)
 	return rgb(r,g,b)
 
-
-
 /proc/convert_k2c(var/temp)
 	return ((temp - T0C))
 
 /proc/convert_c2k(var/temp)
 	return ((temp + T0C))
-

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -107,7 +107,7 @@ AngleToHue(hue)
     Converts an angle to a hue in the valid range.
 RotateHue(hsv, angle)
     Takes an HSV or HSVA value and rotates the hue forward through red, green, and blue by an angle from 0 to 360.
-    (Rotating red by 60° produces yellow.) The result is another HSV or HSVA color with the same saturation and value
+    (Rotating red by 60ï¿½ produces yellow.) The result is another HSV or HSVA color with the same saturation and value
     as the original, but a different hue.
 GrayScale(rgb)
     Takes an RGB or RGBA color and converts it to grayscale. Returns an RGB or RGBA string.
@@ -215,85 +215,84 @@ world
 
 #define TO_HEX_DIGIT(n) ascii2text((n&15) + ((n&15)<10 ? 48 : 87))
 
-icon
-	proc/MakeLying()
-		var/icon/I = new(src,dir=SOUTH)
-		I.BecomeLying()
-		return I
+/icon/proc/MakeLying()
+	var/icon/I = new(src,dir=SOUTH)
+	I.BecomeLying()
+	return I
 
-	proc/BecomeLying()
-		Turn(90)
-		Shift(SOUTH,6)
-		Shift(EAST,1)
+/icon/proc/BecomeLying()
+	Turn(90)
+	Shift(SOUTH,6)
+	Shift(EAST,1)
 
-	// Multiply all alpha values by this float
-	proc/ChangeOpacity(opacity = 1.0)
-		MapColors(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,opacity, 0,0,0,0)
+// Multiply all alpha values by this float
+/icon/proc/ChangeOpacity(opacity = 1.0)
+	MapColors(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,opacity, 0,0,0,0)
 
-	// Convert to grayscale
-	proc/GrayScale()
-		MapColors(0.3,0.3,0.3, 0.59,0.59,0.59, 0.11,0.11,0.11, 0,0,0)
+// Convert to grayscale
+/icon/proc/GrayScale()
+	MapColors(0.3,0.3,0.3, 0.59,0.59,0.59, 0.11,0.11,0.11, 0,0,0)
 
-	proc/ColorTone(tone)
-		GrayScale()
+/icon/proc/ColorTone(tone)
+	GrayScale()
 
-		var/list/TONE = ReadRGB(tone)
-		var/gray = round(TONE[1]*0.3 + TONE[2]*0.59 + TONE[3]*0.11, 1)
+	var/list/TONE = ReadRGB(tone)
+	var/gray = round(TONE[1]*0.3 + TONE[2]*0.59 + TONE[3]*0.11, 1)
 
-		var/icon/upper = (255-gray) ? new(src) : null
+	var/icon/upper = (255-gray) ? new(src) : null
 
-		if(gray)
-			MapColors(255/gray,0,0, 0,255/gray,0, 0,0,255/gray, 0,0,0)
-			Blend(tone, ICON_MULTIPLY)
-		else SetIntensity(0)
-		if(255-gray)
-			upper.Blend(rgb(gray,gray,gray), ICON_SUBTRACT)
-			upper.MapColors((255-TONE[1])/(255-gray),0,0,0, 0,(255-TONE[2])/(255-gray),0,0, 0,0,(255-TONE[3])/(255-gray),0, 0,0,0,0, 0,0,0,1)
-			Blend(upper, ICON_ADD)
+	if(gray)
+		MapColors(255/gray,0,0, 0,255/gray,0, 0,0,255/gray, 0,0,0)
+		Blend(tone, ICON_MULTIPLY)
+	else SetIntensity(0)
+	if(255-gray)
+		upper.Blend(rgb(gray,gray,gray), ICON_SUBTRACT)
+		upper.MapColors((255-TONE[1])/(255-gray),0,0,0, 0,(255-TONE[2])/(255-gray),0,0, 0,0,(255-TONE[3])/(255-gray),0, 0,0,0,0, 0,0,0,1)
+		Blend(upper, ICON_ADD)
 
-	// Take the minimum color of two icons; combine transparency as if blending with ICON_ADD
-	proc/MinColors(icon)
-		var/icon/I = new(src)
-		I.Opaque()
-		I.Blend(icon, ICON_SUBTRACT)
-		Blend(I, ICON_SUBTRACT)
+// Take the minimum color of two icons; combine transparency as if blending with ICON_ADD
+/icon/proc/MinColors(icon)
+	var/icon/I = new(src)
+	I.Opaque()
+	I.Blend(icon, ICON_SUBTRACT)
+	Blend(I, ICON_SUBTRACT)
 
-	// Take the maximum color of two icons; combine opacity as if blending with ICON_OR
-	proc/MaxColors(icon)
-		var/icon/I
-		if(isicon(icon))
-			I = new(icon)
-		else
-			// solid color
-			I = new(src)
-			I.Blend("#000000", ICON_OVERLAY)
-			I.SwapColor("#000000", null)
-			I.Blend(icon, ICON_OVERLAY)
-		var/icon/J = new(src)
-		J.Opaque()
-		I.Blend(J, ICON_SUBTRACT)
-		Blend(I, ICON_OR)
+// Take the maximum color of two icons; combine opacity as if blending with ICON_OR
+/icon/proc/MaxColors(icon)
+	var/icon/I
+	if(isicon(icon))
+		I = new(icon)
+	else
+		// solid color
+		I = new(src)
+		I.Blend("#000000", ICON_OVERLAY)
+		I.SwapColor("#000000", null)
+		I.Blend(icon, ICON_OVERLAY)
+	var/icon/J = new(src)
+	J.Opaque()
+	I.Blend(J, ICON_SUBTRACT)
+	Blend(I, ICON_OR)
 
-	// make this icon fully opaque--transparent pixels become black
-	proc/Opaque(background = "#000000")
-		SwapColor(null, background)
-		MapColors(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,0, 0,0,0,1)
+// make this icon fully opaque--transparent pixels become black
+/icon/proc/Opaque(background = "#000000")
+	SwapColor(null, background)
+	MapColors(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,0, 0,0,0,1)
 
-	// Change a grayscale icon into a white icon where the original color becomes the alpha
-	// I.e., black -> transparent, gray -> translucent white, white -> solid white
-	proc/BecomeAlphaMask()
-		SwapColor(null, "#000000ff")	// don't let transparent become gray
-		MapColors(0,0,0,0.3, 0,0,0,0.59, 0,0,0,0.11, 0,0,0,0, 1,1,1,0)
+// Change a grayscale icon into a white icon where the original color becomes the alpha
+// I.e., black -> transparent, gray -> translucent white, white -> solid white
+/icon/proc/BecomeAlphaMask()
+	SwapColor(null, "#000000ff")	// don't let transparent become gray
+	MapColors(0,0,0,0.3, 0,0,0,0.59, 0,0,0,0.11, 0,0,0,0, 1,1,1,0)
 
-	proc/UseAlphaMask(mask)
-		Opaque()
-		AddAlphaMask(mask)
+/icon/proc/UseAlphaMask(mask)
+	Opaque()
+	AddAlphaMask(mask)
 
-	proc/AddAlphaMask(mask)
-		var/icon/M = new(mask)
-		M.Blend("#ffffff", ICON_SUBTRACT)
-		// apply mask
-		Blend(M, ICON_ADD)
+/icon/proc/AddAlphaMask(mask)
+	var/icon/M = new(mask)
+	M.Blend("#ffffff", ICON_SUBTRACT)
+	// apply mask
+	Blend(M, ICON_ADD)
 
 /*
 	HSV format is represented as "#hhhssvv" or "#hhhssvvaa"
@@ -317,7 +316,7 @@ icon
 		Higher value means brighter color
  */
 
-proc/ReadRGB(rgb)
+/proc/ReadRGB(rgb)
 	if(!rgb) return
 
 	// interpret the HSV or HSVA value
@@ -367,7 +366,7 @@ proc/ReadRGB(rgb)
 	. = list(r, g, b)
 	if(usealpha) . += alpha
 
-proc/ReadHSV(hsv)
+/proc/ReadHSV(hsv)
 	if(!hsv) return
 
 	// interpret the HSV or HSVA value
@@ -406,7 +405,7 @@ proc/ReadHSV(hsv)
 	. = list(hue, sat, val)
 	if(usealpha) . += alpha
 
-proc/HSVtoRGB(hsv)
+/proc/HSVtoRGB(hsv)
 	if(!hsv) return "#000000"
 	var/list/HSV = ReadHSV(hsv)
 	if(!HSV) return "#000000"
@@ -434,7 +433,7 @@ proc/HSVtoRGB(hsv)
 
 	return (HSV.len > 3) ? rgb(r,g,b,HSV[4]) : rgb(r,g,b)
 
-proc/RGBtoHSV(rgb)
+/proc/RGBtoHSV(rgb)
 	if(!rgb) return "#0000000"
 	var/list/RGB = ReadRGB(rgb)
 	if(!RGB) return "#0000000"
@@ -465,7 +464,7 @@ proc/RGBtoHSV(rgb)
 
 	return hsv(hue, sat, val, (RGB.len>3 ? RGB[4] : null))
 
-proc/hsv(hue, sat, val, alpha)
+/proc/hsv(hue, sat, val, alpha)
 	if(hue < 0 || hue >= 1536) hue %= 1536
 	if(hue < 0) hue += 1536
 	if((hue & 0xFF) == 0xFF)
@@ -498,7 +497,7 @@ proc/hsv(hue, sat, val, alpha)
 
 	amount<0 or amount>1 are allowed
  */
-proc/BlendHSV(hsv1, hsv2, amount)
+/proc/BlendHSV(hsv1, hsv2, amount)
 	var/list/HSV1 = ReadHSV(hsv1)
 	var/list/HSV2 = ReadHSV(hsv2)
 
@@ -552,7 +551,7 @@ proc/BlendHSV(hsv1, hsv2, amount)
 
 	amount<0 or amount>1 are allowed
  */
-proc/BlendRGB(rgb1, rgb2, amount)
+/proc/BlendRGB(rgb1, rgb2, amount)
 	var/list/RGB1 = ReadRGB(rgb1)
 	var/list/RGB2 = ReadRGB(rgb2)
 
@@ -568,10 +567,10 @@ proc/BlendRGB(rgb1, rgb2, amount)
 
 	return isnull(alpha) ? rgb(r, g, b) : rgb(r, g, b, alpha)
 
-proc/BlendRGBasHSV(rgb1, rgb2, amount)
+/proc/BlendRGBasHSV(rgb1, rgb2, amount)
 	return HSVtoRGB(RGBtoHSV(rgb1), RGBtoHSV(rgb2), amount)
 
-proc/HueToAngle(hue)
+/proc/HueToAngle(hue)
 	// normalize hsv in case anything is screwy
 	if(hue < 0 || hue >= 1536) hue %= 1536
 	if(hue < 0) hue += 1536
@@ -579,7 +578,7 @@ proc/HueToAngle(hue)
 	hue -= hue >> 8
 	return hue / (1530/360)
 
-proc/AngleToHue(angle)
+/proc/AngleToHue(angle)
 	// normalize hsv in case anything is screwy
 	if(angle < 0 || angle >= 360) angle -= 360 * round(angle / 360)
 	var/hue = angle * (1530/360)
@@ -587,9 +586,8 @@ proc/AngleToHue(angle)
 	hue += round(hue / 255)
 	return hue
 
-
 // positive angle rotates forward through red->green->blue
-proc/RotateHue(hsv, angle)
+/proc/RotateHue(hsv, angle)
 	var/list/HSV = ReadHSV(hsv)
 
 	// normalize hsv in case anything is screwy
@@ -611,13 +609,13 @@ proc/RotateHue(hsv, angle)
 	return hsv(HSV[1], HSV[2], HSV[3], (HSV.len > 3 ? HSV[4] : null))
 
 // Convert an rgb color to grayscale
-proc/GrayScale(rgb)
+/proc/GrayScale(rgb)
 	var/list/RGB = ReadRGB(rgb)
 	var/gray = RGB[1]*0.3 + RGB[2]*0.59 + RGB[3]*0.11
 	return (RGB.len > 3) ? rgb(gray, gray, gray, RGB[4]) : rgb(gray, gray, gray)
 
 // Change grayscale color to black->tone->white range
-proc/ColorTone(rgb, tone)
+/proc/ColorTone(rgb, tone)
 	var/list/RGB = ReadRGB(rgb)
 	var/list/TONE = ReadRGB(tone)
 
@@ -627,171 +625,170 @@ proc/ColorTone(rgb, tone)
 	if(gray <= tone_gray) return BlendRGB("#000000", tone, gray/(tone_gray || 1))
 	else return BlendRGB(tone, "#ffffff", (gray-tone_gray)/((255-tone_gray) || 1))
 
-
 /*
 Get flat icon by DarkCampainger. As it says on the tin, will return an icon with all the overlays
 as a single icon. Useful for when you want to manipulate an icon via the above as overlays are not normally included.
 The _flatIcons list is a cache for generated icon files.
 */
 
-proc // Creates a single icon from a given /atom or /image.  Only the first argument is required.
-	getFlatIcon(image/A, defdir=2, deficon=null, defstate="", defblend=BLEND_DEFAULT)
-		// We start with a blank canvas, otherwise some icon procs crash silently
-		var/icon/flat = icon('icons/effects/effects.dmi', "icon_state"="nothing") // Final flattened icon
-		if(!A)
-			return flat
-		if(A.alpha <= 0)
-			return flat
-		var/noIcon = FALSE
+// Creates a single icon from a given /atom or /image.  Only the first argument is required.
+/proc/getFlatIcon(image/A, defdir=2, deficon=null, defstate="", defblend=BLEND_DEFAULT)
+	// We start with a blank canvas, otherwise some icon procs crash silently
+	var/icon/flat = icon('icons/effects/effects.dmi', "icon_state"="nothing") // Final flattened icon
+	if(!A)
+		return flat
+	if(A.alpha <= 0)
+		return flat
+	var/noIcon = FALSE
 
-		var/curicon
-		if(A.icon)
-			curicon = A.icon
+	var/curicon
+	if(A.icon)
+		curicon = A.icon
+	else
+		curicon = deficon
+
+	if(!curicon)
+		noIcon = TRUE // Do not render this object.
+
+	var/curstate
+	if(A.icon_state)
+		curstate = A.icon_state
+	else
+		curstate = defstate
+
+	if(!noIcon && !(curstate in icon_states(curicon)))
+		if("" in icon_states(curicon))
+			curstate = ""
 		else
-			curicon = deficon
-
-		if(!curicon)
 			noIcon = TRUE // Do not render this object.
 
-		var/curstate
-		if(A.icon_state)
-			curstate = A.icon_state
-		else
-			curstate = defstate
+	var/curdir
+	if(A.dir != 2)
+		curdir = A.dir
+	else
+		curdir = defdir
 
-		if(!noIcon && !(curstate in icon_states(curicon)))
-			if("" in icon_states(curicon))
-				curstate = ""
-			else
-				noIcon = TRUE // Do not render this object.
+	var/curblend
+	if(A.blend_mode == BLEND_DEFAULT)
+		curblend = defblend
+	else
+		curblend = A.blend_mode
 
-		var/curdir
-		if(A.dir != 2)
-			curdir = A.dir
-		else
-			curdir = defdir
+	// Layers will be a sorted list of icons/overlays, based on the order in which they are displayed
+	var/list/layers = list()
+	var/image/copy
+	// Add the atom's icon itself, without pixel_x/y offsets.
+	if(!noIcon)
+		copy = image(icon=curicon, icon_state=curstate, layer=A.layer, dir=curdir)
+		copy.color = A.color
+		copy.alpha = A.alpha
+		copy.blend_mode = curblend
+		layers[copy] = A.layer
 
-		var/curblend
-		if(A.blend_mode == BLEND_DEFAULT)
-			curblend = defblend
-		else
-			curblend = A.blend_mode
+	// Loop through the underlays, then overlays, sorting them into the layers list
+	var/list/process = A.underlays // Current list being processed
+	var/pSet=0 // Which list is being processed: 0 = underlays, 1 = overlays
+	var/curIndex=1 // index of 'current' in list being processed
+	var/current // Current overlay being sorted
+	var/currentLayer // Calculated layer that overlay appears on (special case for FLOAT_LAYER)
+	var/compare // The overlay 'add' is being compared against
+	var/cmpIndex // The index in the layers list of 'compare'
+	while(TRUE)
+		if(curIndex<=process.len)
+			current = process[curIndex]
+			if(current)
+				currentLayer = current:layer
+				if(currentLayer<0) // Special case for FLY_LAYER
+					if(currentLayer <= -1000) return flat
+					if(pSet == 0) // Underlay
+						currentLayer = A.layer+currentLayer/1000
+					else // Overlay
+						currentLayer = A.layer+(1000+currentLayer)/1000
 
-		// Layers will be a sorted list of icons/overlays, based on the order in which they are displayed
-		var/list/layers = list()
-		var/image/copy
-		// Add the atom's icon itself, without pixel_x/y offsets.
-		if(!noIcon)
-			copy = image(icon=curicon, icon_state=curstate, layer=A.layer, dir=curdir)
-			copy.color = A.color
-			copy.alpha = A.alpha
-			copy.blend_mode = curblend
-			layers[copy] = A.layer
+				// Sort add into layers list
+				for(cmpIndex=1,cmpIndex<=layers.len,cmpIndex++)
+					compare = layers[cmpIndex]
+					if(currentLayer < layers[compare]) // Associated value is the calculated layer
+						layers.Insert(cmpIndex,current)
+						layers[current] = currentLayer
+						break
+				if(cmpIndex>layers.len) // Reached end of list without inserting
+					layers[current]=currentLayer // Place at end
 
-		// Loop through the underlays, then overlays, sorting them into the layers list
-		var/list/process = A.underlays // Current list being processed
-		var/pSet=0 // Which list is being processed: 0 = underlays, 1 = overlays
-		var/curIndex=1 // index of 'current' in list being processed
-		var/current // Current overlay being sorted
-		var/currentLayer // Calculated layer that overlay appears on (special case for FLOAT_LAYER)
-		var/compare // The overlay 'add' is being compared against
-		var/cmpIndex // The index in the layers list of 'compare'
-		while(TRUE)
-			if(curIndex<=process.len)
-				current = process[curIndex]
-				if(current)
-					currentLayer = current:layer
-					if(currentLayer<0) // Special case for FLY_LAYER
-						if(currentLayer <= -1000) return flat
-						if(pSet == 0) // Underlay
-							currentLayer = A.layer+currentLayer/1000
-						else // Overlay
-							currentLayer = A.layer+(1000+currentLayer)/1000
+			curIndex++
+		else if(pSet == 0) // Switch to overlays
+			curIndex = 1
+			pSet = 1
+			process = A.overlays
+		else // All done
+			break
 
-					// Sort add into layers list
-					for(cmpIndex=1,cmpIndex<=layers.len,cmpIndex++)
-						compare = layers[cmpIndex]
-						if(currentLayer < layers[compare]) // Associated value is the calculated layer
-							layers.Insert(cmpIndex,current)
-							layers[current] = currentLayer
-							break
-					if(cmpIndex>layers.len) // Reached end of list without inserting
-						layers[current]=currentLayer // Place at end
+	var/icon/add // Icon of overlay being added
 
-				curIndex++
-			else if(pSet == 0) // Switch to overlays
-				curIndex = 1
-				pSet = 1
-				process = A.overlays
-			else // All done
-				break
+		// Current dimensions of flattened icon
+	var/{flatX1=1;flatX2=flat.Width();flatY1=1;flatY2=flat.Height()}
+		// Dimensions of overlay being added
+	var/{addX1;addX2;addY1;addY2}
 
-		var/icon/add // Icon of overlay being added
+	for(var/I in layers)
 
-			// Current dimensions of flattened icon
-		var/{flatX1=1;flatX2=flat.Width();flatY1=1;flatY2=flat.Height()}
-			// Dimensions of overlay being added
-		var/{addX1;addX2;addY1;addY2}
+		if(I:alpha == 0)
+			continue
 
-		for(var/I in layers)
-
-			if(I:alpha == 0)
-				continue
-
-			if(I == copy) // 'I' is an /image based on the object being flattened.
-				curblend = BLEND_OVERLAY
-				add = icon(I:icon, I:icon_state, I:dir)
-				// This checks for a silent failure mode of the icon routine. If the requested dir
-				// doesn't exist in this icon state it returns a 32x32 icon with 0 alpha.
-				if (I:dir != SOUTH && add.Width() == 32 && add.Height() == 32)
-					// Check every pixel for blank (computationally expensive, but the process is limited
-					// by the amount of film on the station, only happens when we hit something that's
-					// turned, and bails at the very first pixel it sees.
-					var/blankpixel;
-					for(var/y;y<=32;y++)
-						for(var/x;x<32;x++)
-							blankpixel = isnull(add.GetPixel(x,y))
-							if(!blankpixel)
-								break
+		if(I == copy) // 'I' is an /image based on the object being flattened.
+			curblend = BLEND_OVERLAY
+			add = icon(I:icon, I:icon_state, I:dir)
+			// This checks for a silent failure mode of the icon routine. If the requested dir
+			// doesn't exist in this icon state it returns a 32x32 icon with 0 alpha.
+			if (I:dir != SOUTH && add.Width() == 32 && add.Height() == 32)
+				// Check every pixel for blank (computationally expensive, but the process is limited
+				// by the amount of film on the station, only happens when we hit something that's
+				// turned, and bails at the very first pixel it sees.
+				var/blankpixel;
+				for(var/y;y<=32;y++)
+					for(var/x;x<32;x++)
+						blankpixel = isnull(add.GetPixel(x,y))
 						if(!blankpixel)
 							break
-					// If we ALWAYS returned a null (which happens when GetPixel encounters something with alpha 0)
-					if (blankpixel)
-						// Pull the default direction.
-						add = icon(I:icon, I:icon_state)
-			else // 'I' is an appearance object.
-				add = getFlatIcon(new/image(I), curdir, curicon, curstate, curblend)
+					if(!blankpixel)
+						break
+				// If we ALWAYS returned a null (which happens when GetPixel encounters something with alpha 0)
+				if (blankpixel)
+					// Pull the default direction.
+					add = icon(I:icon, I:icon_state)
+		else // 'I' is an appearance object.
+			add = getFlatIcon(new/image(I), curdir, curicon, curstate, curblend)
 
-			// Find the new dimensions of the flat icon to fit the added overlay
-			addX1 = min(flatX1, I:pixel_x+1)
-			addX2 = max(flatX2, I:pixel_x+add.Width())
-			addY1 = min(flatY1, I:pixel_y+1)
-			addY2 = max(flatY2, I:pixel_y+add.Height())
+		// Find the new dimensions of the flat icon to fit the added overlay
+		addX1 = min(flatX1, I:pixel_x+1)
+		addX2 = max(flatX2, I:pixel_x+add.Width())
+		addY1 = min(flatY1, I:pixel_y+1)
+		addY2 = max(flatY2, I:pixel_y+add.Height())
 
-			if(addX1!=flatX1 || addX2!=flatX2 || addY1!=flatY1 || addY2!=flatY2)
-				// Resize the flattened icon so the new icon fits
-				flat.Crop(addX1-flatX1+1, addY1-flatY1+1, addX2-flatX1+1, addY2-flatY1+1)
-				flatX1=addX1;flatX2=addX2
-				flatY1=addY1;flatY2=addY2
+		if(addX1!=flatX1 || addX2!=flatX2 || addY1!=flatY1 || addY2!=flatY2)
+			// Resize the flattened icon so the new icon fits
+			flat.Crop(addX1-flatX1+1, addY1-flatY1+1, addX2-flatX1+1, addY2-flatY1+1)
+			flatX1=addX1;flatX2=addX2
+			flatY1=addY1;flatY2=addY2
 
-			// Blend the overlay into the flattened icon
-			flat.Blend(add, blendMode2iconMode(curblend), I:pixel_x + 2 - flatX1, I:pixel_y + 2 - flatY1)
+		// Blend the overlay into the flattened icon
+		flat.Blend(add, blendMode2iconMode(curblend), I:pixel_x + 2 - flatX1, I:pixel_y + 2 - flatY1)
 
-		if(A.color)
-			flat.Blend(A.color, ICON_MULTIPLY)
-		if(A.alpha < 255)
-			flat.Blend(rgb(255, 255, 255, A.alpha), ICON_MULTIPLY)
+	if(A.color)
+		flat.Blend(A.color, ICON_MULTIPLY)
+	if(A.alpha < 255)
+		flat.Blend(rgb(255, 255, 255, A.alpha), ICON_MULTIPLY)
 
-		return icon(flat, "", SOUTH)
+	return icon(flat, "", SOUTH)
 
-	getIconMask(atom/A)//By yours truly. Creates a dynamic mask for a mob/whatever. /N
-		var/icon/alpha_mask = new(A.icon,A.icon_state)//So we want the default icon and icon state of A.
-		for(var/I in A.overlays)//For every image in overlays. var/image/I will not work, don't try it.
-			if(I:layer>A.layer)	continue//If layer is greater than what we need, skip it.
-			var/icon/image_overlay = new(I:icon,I:icon_state)//Blend only works with icon objects.
-			//Also, icons cannot directly set icon_state. Slower than changing variables but whatever.
-			alpha_mask.Blend(image_overlay,ICON_OR)//OR so they are lumped together in a nice overlay.
-		return alpha_mask//And now return the mask.
+/proc/getIconMask(atom/A)//By yours truly. Creates a dynamic mask for a mob/whatever. /N
+	var/icon/alpha_mask = new(A.icon,A.icon_state)//So we want the default icon and icon state of A.
+	for(var/I in A.overlays)//For every image in overlays. var/image/I will not work, don't try it.
+		if(I:layer>A.layer)	continue//If layer is greater than what we need, skip it.
+		var/icon/image_overlay = new(I:icon,I:icon_state)//Blend only works with icon objects.
+		//Also, icons cannot directly set icon_state. Slower than changing variables but whatever.
+		alpha_mask.Blend(image_overlay,ICON_OR)//OR so they are lumped together in a nice overlay.
+	return alpha_mask//And now return the mask.
 
 /mob/proc/AddCamoOverlay(atom/A)//A is the atom which we are using as the overlay.
 	var/icon/opacity_icon = new(A.icon, A.icon_state)//Don't really care for overlays/underlays.
@@ -825,7 +822,7 @@ proc // Creates a single icon from a given /atom or /image.  Only the first argu
 		composite.Blend(icon(I.icon, I.icon_state, I.dir, 1), ICON_OVERLAY)
 	return composite
 
-proc/adjust_brightness(var/color, var/value)
+/proc/adjust_brightness(var/color, var/value)
 	if (!color) return "#FFFFFF"
 	if (!value) return color
 
@@ -835,7 +832,7 @@ proc/adjust_brightness(var/color, var/value)
 	RGB[3] = Clamp(RGB[3]+value,0,255)
 	return rgb(RGB[1],RGB[2],RGB[3])
 
-proc/sort_atoms_by_layer(var/list/atoms)
+/proc/sort_atoms_by_layer(var/list/atoms)
 	// Comb sort icons based on levels
 	var/list/result = atoms.Copy()
 	var/gap = result.len

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -31,7 +31,7 @@
 		return "[output][and_text][input[index]]"
 
 //Returns list element or null. Should prevent "index out of bounds" error.
-proc/listgetindex(var/list/list,index)
+/proc/listgetindex(var/list/list,index)
 	if(istype(list) && list.len)
 		if(isnum(index))
 			if(InRange(index,1,list.len))
@@ -40,19 +40,19 @@ proc/listgetindex(var/list/list,index)
 			return list[index]
 	return
 
-proc/islist(list/list)
+/proc/islist(list/list)
 	if(istype(list))
 		return 1
 	return 0
 
 //Return either pick(list) or null if list is not of type /list or is empty
-proc/safepick(list/list)
+/proc/safepick(list/list)
 	if(!islist(list) || !list.len)
 		return
 	return pick(list)
 
 //Checks if the list is empty
-proc/isemptylist(list/list)
+/proc/isemptylist(list/list)
 	if(!list.len)
 		return 1
 	return 0
@@ -65,13 +65,13 @@ proc/isemptylist(list/list)
 	return 0
 
 //Empties the list by setting the length to 0. Hopefully the elements get garbage collected
-proc/clearlist(list/list)
+/proc/clearlist(list/list)
 	if(istype(list))
 		list.len = 0
 	return
 
 //Removes any null entries from the list
-proc/listclearnulls(list/list)
+/proc/listclearnulls(list/list)
 	if(istype(list))
 		while(null in list)
 			list -= null
@@ -233,9 +233,6 @@ proc/listclearnulls(list/list)
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
-
-
-
 //Mergesort: Specifically for record datums in a list.
 /proc/sortRecord(var/list/datum/data/record/L, var/field = "name", var/order = 1)
 	if(isnull(L))
@@ -269,9 +266,6 @@ proc/listclearnulls(list/list)
 			return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
-
-
-
 //Mergesort: any value in a list
 /proc/sortList(var/list/L)
 	if(L.len < 2)
@@ -300,7 +294,6 @@ proc/listclearnulls(list/list)
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
 
-
 // List of lists, sorts by element[key] - for things like crew monitoring computer sorting records by name.
 /proc/sortByKey(var/list/L, var/key)
 	if(L.len < 2)
@@ -324,7 +317,6 @@ proc/listclearnulls(list/list)
 	if(Li <= L.len)
 		return (result + L.Copy(Li, 0))
 	return (result + R.Copy(Ri, 0))
-
 
 //Mergesort: any value in a list, preserves key=value structure
 /proc/sortAssoc(var/list/L)
@@ -404,13 +396,13 @@ proc/listclearnulls(list/list)
 	//world.log << "	output: [out.len]"
 	return reverselist(out)
 
-proc/dd_sortedObjectList(list/incoming)
-	/*
-	   Use binary search to order by dd_SortValue().
-	   This works by going to the half-point of the list, seeing if the node in
-	   question is higher or lower cost, then going halfway up or down the list
-	   and checking again. This is a very fast way to sort an item into a list.
-	*/
+/*
+	Use binary search to order by dd_SortValue().
+	This works by going to the half-point of the list, seeing if the node in
+	question is higher or lower cost, then going halfway up or down the list
+	and checking again. This is a very fast way to sort an item into a list.
+*/
+/proc/dd_sortedObjectList(list/incoming)
 	var/list/sorted_list = new()
 	var/low_index
 	var/high_index
@@ -461,13 +453,14 @@ proc/dd_sortedObjectList(list/incoming)
 		sorted_list += list_bottom
 	return sorted_list
 
-
-proc/dd_sortedtextlist(list/incoming, case_sensitive = 0)
-	// Returns a new list with the text values sorted.
-	// Use binary search to order by sortValue.
-	// This works by going to the half-point of the list, seeing if the node in question is higher or lower cost,
-	// then going halfway up or down the list and checking again.
-	// This is a very fast way to sort an item into a list.
+/*
+	Returns a new list with the text values sorted.
+	Use binary search to order by sortValue.
+	This works by going to the half-point of the list, seeing if the node in question is higher or lower cost,
+	then going halfway up or down the list and checking again.
+	This is a very fast way to sort an item into a list.
+*/
+/proc/dd_sortedtextlist(list/incoming, case_sensitive = 0)
 	var/list/sorted_text = new()
 	var/low_index
 	var/high_index
@@ -520,13 +513,11 @@ proc/dd_sortedtextlist(list/incoming, case_sensitive = 0)
 		sorted_text += list_bottom
 	return sorted_text
 
-
-proc/dd_sortedTextList(list/incoming)
+/proc/dd_sortedTextList(list/incoming)
 	var/case_sensitive = 1
 	return dd_sortedtextlist(incoming, case_sensitive)
 
-
-datum/proc/dd_SortValue()
+/datum/proc/dd_SortValue()
 	return "[src]"
 
 /obj/machinery/dd_SortValue()

--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -1,12 +1,10 @@
 //print an error message to world.log
 
-
 // On Linux/Unix systems the line endings are LF, on windows it's CRLF, admins that don't use notepad++
 // will get logs that are one big line if the system is Linux and they are using notepad.  This solves it by adding CR to every line ending
 // in the logs.  ascii character 13 = CR
 
 /var/global/log_end= world.system_type == UNIX ? ascii2text(13) : ""
-
 
 /proc/error(msg)
 	world.log << "## ERROR: [msg][log_end]"
@@ -25,7 +23,6 @@
 	if (config.log_admin)
 		diary << "\[[time_stamp()]]ADMIN: [text][log_end]"
 
-
 /proc/log_debug(text)
 	if (config.log_debug)
 		diary << "\[[time_stamp()]]DEBUG: [text][log_end]"
@@ -33,7 +30,6 @@
 	for(var/client/C in admins)
 		if(C.prefs.toggles_chat & CHAT_DEBUGLOGS)
 			C << "DEBUG: [text]"
-
 
 /proc/log_game(text)
 	if (config.log_game)

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -84,7 +84,6 @@ var/list/sqrtTable = list(1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 
 		sum += val
 	return sum / values
 
-
 // Returns the nth root of x.
 /proc/Root(n, x)
 	return x ** (1 / n)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -1,10 +1,10 @@
-proc/random_ethnicity()
+/proc/random_ethnicity()
 	return pick(ethnicities_list)
 
-proc/random_body_type()
+/proc/random_body_type()
 	return pick(body_types_list)
 
-proc/random_hair_style(gender, species = "Human")
+/proc/random_hair_style(gender, species = "Human")
 	var/h_style = "Crewcut"
 
 	var/list/valid_hairstyles = list()
@@ -23,8 +23,7 @@ proc/random_hair_style(gender, species = "Human")
 
 	return h_style
 
-
-proc/random_facial_hair_style(gender, species = "Human")
+/proc/random_facial_hair_style(gender, species = "Human")
 	var/f_style = "Shaved"
 
 	var/list/valid_facialhairstyles = list()
@@ -44,11 +43,11 @@ proc/random_facial_hair_style(gender, species = "Human")
 
 		return f_style
 
-proc/random_name(gender, species = "Human")
+/proc/random_name(gender, species = "Human")
 	if(gender==FEMALE)	return capitalize(pick(first_names_female)) + " " + capitalize(pick(last_names))
 	else				return capitalize(pick(first_names_male)) + " " + capitalize(pick(last_names))
 
-proc/random_skin_tone()
+/proc/random_skin_tone()
 	switch(pick(60;"caucasian", 15;"afroamerican", 10;"african", 10;"latino", 5;"albino"))
 		if("caucasian")		. = -10
 		if("afroamerican")	. = -115
@@ -58,7 +57,7 @@ proc/random_skin_tone()
 		else				. = rand(-185,34)
 	return min(max( .+rand(-25, 25), -185),34)
 
-proc/skintone2racedescription(tone)
+/proc/skintone2racedescription(tone)
 	switch (tone)
 		if(30 to INFINITY)		return "albino"
 		if(20 to 30)			return "pale"
@@ -70,7 +69,7 @@ proc/skintone2racedescription(tone)
 		if(-INFINITY to -65)	return "black"
 		else					return "unknown"
 
-proc/age2agedescription(age)
+/proc/age2agedescription(age)
 	switch(age)
 		if(0 to 1)			return "infant"
 		if(1 to 3)			return "toddler"
@@ -83,8 +82,7 @@ proc/age2agedescription(age)
 		if(70 to INFINITY)	return "elderly"
 		else				return "unknown"
 
-
-proc/has_species(var/mob/M, var/species)
+/proc/has_species(var/mob/M, var/species)
 	if(!M || !istype(M,/mob/living/carbon/human)) return 0
 	var/mob/living/carbon/human/H = M
 

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -96,7 +96,6 @@ var/religion_name = null
 		if(13)
 			station_name += pick("13","XIII","Thirteen")
 
-
 	if (config && config.server_name)
 		world.name = "[config.server_name]: [name]"
 	else
@@ -144,7 +143,6 @@ var/syndicate_name = null
 
 	syndicate_name = name
 	return name
-
 
 //Traitors and traitor silicons will get these. Revs will not.
 var/syndicate_code_phrase//Code phrase for traitors.
@@ -238,7 +236,6 @@ var/syndicate_code_response//Code response for traitors.
 
 	world << "\red Code Phrase is: \black [generate_code_phrase()]"
 	return
-
 
 	This was an earlier attempt at code phrase system, aside from an even earlier attempt (and failure).
 	This system more or less works as intended--aside from being unfinished--but it's still very predictable.

--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -16,8 +16,6 @@
 	if(default)			return default
 	if(List && List.len)return List[1]
 
-
-
 //more specialised stuff
 /proc/sanitize_gender(gender,neuter=0,plural=0, default="male")
 	switch(gender)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -8,7 +8,6 @@
  *			Misc
  */
 
-
 /*
  * SQL sanitization
  */
@@ -64,7 +63,6 @@
 //I believe strip_html_simple() is required to run first to prevent '<' from displaying as '&lt;' that html_encode() would cause
 /proc/adminscrub(var/t,var/limit=MAX_MESSAGE_LEN)
 	return copytext((html_encode(strip_html_simple(t))),1,limit)
-
 
 //Returns null if there is any bad text in the string
 /proc/reject_bad_text(var/text, var/max_length=512)
@@ -156,7 +154,7 @@
 //checks text for html tags
 //if tag is not in whitelist (var/list/paper_tag_whitelist in global.dm)
 //relpaces < with &lt;
-proc/checkhtml(var/t)
+/proc/checkhtml(var/t)
 	t = sanitize_simple(t, list("&#"="."))
 	var/p = findtext(t,"<",1)
 	while (p)	//going through all the tags
@@ -278,7 +276,6 @@ proc/checkhtml(var/t)
 		return message
 	return copytext(message, 1, length + 1)
 
-
 /proc/stringmerge(var/text,var/compare,replace = "*")
 //This proc fills in all spaces with the "replace" var (* by default) with whatever
 //is in the other string at the same spot (assuming it is not a replace char).
@@ -320,7 +317,7 @@ proc/checkhtml(var/t)
 
 //Used in preferences' SetFlavorText and human's set_flavor verb
 //Previews a string of len or less length
-proc/TextPreview(var/string,var/len=40)
+/proc/TextPreview(var/string,var/len=40)
 	if(lentext(string) <= len)
 		if(!lentext(string))
 			return "\[...\]"

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -4,17 +4,17 @@
 #define MINUTE *600
 #define MINUTES *600
 
-proc/worldtime2text(time = world.time) // Shows current time starting at noon 12:00 (station time)
+/proc/worldtime2text(time = world.time) // Shows current time starting at noon 12:00 (station time)
 	return "[round(time / 36000)+12]:[(time / 600 % 60) < 10 ? add_zero(time / 600 % 60, 1) : time / 600 % 60]"
 
-proc/time_stamp() // Shows current GMT time
+/proc/time_stamp() // Shows current GMT time
 	return time2text(world.timeofday, "hh:mm:ss")
 
-proc/duration2text(time = world.time) // Shows current time starting at 0:00
+/proc/duration2text(time = world.time) // Shows current time starting at 0:00
 	return "[round(time / 36000)]:[(time / 600 % 60) < 10 ? add_zero(time / 600 % 60, 1) : time / 600 % 60]"
 
 /* Preserving this so future generations can see how fucking retarded some people are
-proc/time_stamp()
+/proc/time_stamp()
 	var/hh = text2num(time2text(world.timeofday, "hh")) // Set the hour
 	var/mm = text2num(time2text(world.timeofday, "mm")) // Set the minute
 	var/ss = text2num(time2text(world.timeofday, "ss")) // Set the second
@@ -28,7 +28,7 @@ proc/time_stamp()
 */
 
 /* Returns 1 if it is the selected month and day */
-proc/isDay(var/month, var/day)
+/proc/isDay(var/month, var/day)
 	if(isnum(month) && isnum(day))
 		var/MM = text2num(time2text(world.timeofday, "MM")) // get the current month
 		var/DD = text2num(time2text(world.timeofday, "DD")) // get the current day

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -84,7 +84,6 @@
 		hex = text("0[]", hex)
 	return hex
 
-
 // Concatenates a list of strings into a single string.  A seperator may optionally be provided.
 /proc/list2text(list/ls, sep)
 	if(ls.len <= 1) // Early-out code for empty or singleton lists.
@@ -171,16 +170,14 @@
 		#undef S4
 		#undef S1
 
-
 //slower then list2text, but correctly processes associative lists.
-proc/tg_list2text(list/list, glue=",")
+/proc/tg_list2text(list/list, glue=",")
 	if(!istype(list) || !list.len)
 		return
 	var/output
 	for(var/i=1 to list.len)
 		output += (i!=1? glue : null)+(!isnull(list["[list[i]]"])?"[list["[list[i]]"]]":"[list[i]]")
 	return output
-
 
 //Converts a string into a list by splitting the string at each delimiter found. (discarding the seperator)
 /proc/text2list(text, delimiter="\n")
@@ -212,9 +209,7 @@ proc/tg_list2text(list/list, glue=",")
 /proc/file2list(filename, seperator="\n")
 	return text2list(return_file_text(filename),seperator)
 
-
 //Turns a direction into text
-
 /proc/num2dir(direction)
 	switch(direction)
 		if(1.0) return NORTH
@@ -223,8 +218,6 @@ proc/tg_list2text(list/list, glue=",")
 		if(8.0) return WEST
 		else
 			world.log << "UNKNOWN DIRECTION: [direction]"
-
-
 
 //Turns a direction into text
 /proc/dir2text(direction)
@@ -246,7 +239,6 @@ proc/tg_list2text(list/list, glue=",")
 		if(10.0)
 			return "southwest"
 
-
 //Turns a direction into text
 /proc/dir2text_short(direction)
 	switch(direction)
@@ -266,8 +258,6 @@ proc/tg_list2text(list/list, glue=",")
 			return "NW"
 		if(10)
 			return "SW"
-
-
 
 //Turns text into proper directions
 /proc/text2dir(direction)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -42,7 +42,6 @@
 	if(A > upper) return 0
 	return 1
 
-
 /proc/Get_Angle(atom/start,atom/end)//For beams.
 	if(!start || !end) return 0
 	if(!start.z || !end.z) return 0 //Atoms are not on turfs.
@@ -184,7 +183,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	return destination
 
-
 //among other things, used by flamethrower and boiler spray to calculate if flame/spray can pass through.
 /proc/LinkBlocked(turf/A, turf/B)
 	if(A == null || B == null) return 1
@@ -223,8 +221,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			return 1
 	return 0
 
-
-
 /proc/sign(x)
 	return x!=0?x/abs(x):0
 
@@ -256,8 +252,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //Turns 1479 into 147.9
 /proc/format_frequency(var/f)
 	return "[round(f / 10)].[f % 10]"
-
-
 
 //This will update a mob's name, real_name, mind.name, data_core records, pda and id
 //Calling this proc without an oldname will only update the mob and skip updating the pda, id and records ~Carn
@@ -301,8 +295,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 					search_pda = 0
 	return 1
 
-
-
 //Generalised helper proc for letting mobs rename themselves. Used to be clname() and ainame()
 //Last modified by Carn
 /mob/proc/rename_self(var/role, var/allow_numbers=0)
@@ -340,10 +332,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 				// Set eyeobj name
 				A.SetName(newname)
 
-
 		fully_replace_character_name(oldname,newname)
-
-
 
 //Picks a string of symbols to display as the law number for hacked or ion laws
 /proc/ionnum()
@@ -589,7 +578,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	if(M < 0)
 		return -M
 
-
 /proc/key_name(var/whom, var/include_link = null, var/include_name = 1, var/highlight_special_characters = 1)
 	var/mob/M
 	var/client/C
@@ -635,7 +623,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		else if(M.name)
 			name = M.name
 
-
 		if(include_link && is_special_character(M) && highlight_special_characters)
 			. += "/(<font color='#FFA500'>[name]</font>)" //Orange
 		else
@@ -645,7 +632,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 /proc/key_name_admin(var/whom, var/include_name = 1)
 	return key_name(whom, 1, include_name)
-
 
 // returns the turf located at the map edge in the specified direction relative to A
 // used for mass driver
@@ -688,7 +674,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	return locate(x,y,A.z)
 
-
 // returns turf relative to A offset in dx and dy tiles
 // bound to map limits
 /proc/get_offset_target_turf(var/atom/A, var/dx, var/dy)
@@ -700,12 +685,12 @@ Turf and target are seperate in case you want to teleport some distance from a t
 /proc/between(var/low, var/middle, var/high)
 	return max(min(middle, high), low)
 
-proc/arctan(x)
+/proc/arctan(x)
 	var/y=arcsin(x/sqrt(1+x*x))
 	return y
 
 //returns random gauss number
-proc/GaussRand(var/sigma)
+/proc/GaussRand(var/sigma)
   var/x,y,rsq
   do
     x=2*rand()-1
@@ -715,10 +700,10 @@ proc/GaussRand(var/sigma)
   return sigma*y*sqrt(-2*log(rsq)/rsq)
 
 //returns random gauss number, rounded to 'roundto'
-proc/GaussRandRound(var/sigma,var/roundto)
+/proc/GaussRandRound(var/sigma,var/roundto)
 	return round(GaussRand(sigma),roundto)
 
-proc/anim(turf/location,atom/target,a_icon,a_icon_state as text,flick_anim as text,sleeptime = 0,direction as num)
+/proc/anim(turf/location,atom/target,a_icon,a_icon_state as text,flick_anim as text,sleeptime = 0,direction as num)
 //This proc throws up either an icon or an animation for a specified amount of time.
 //The variables should be apparent enough.
 	var/atom/movable/overlay/animation = new(location)
@@ -798,7 +783,6 @@ proc/anim(turf/location,atom/target,a_icon,a_icon_state as text,flick_anim as te
 
 	else return get_step(ref, base_dir)
 
-
 var/global/image/busy_indicator_clock
 var/global/image/busy_indicator_medical
 var/global/image/busy_indicator_build
@@ -831,8 +815,6 @@ var/global/image/busy_indicator_hostile
 			busy_indicator_hostile = image('icons/mob/mob.dmi', null, "busy_hostile", "pixel_y" = 22)
 			busy_indicator_hostile.layer = FLY_LAYER
 		return busy_indicator_hostile
-
-
 
 /proc/do_mob(mob/user , mob/target, time = 30, show_busy_icon, show_target_icon, selected_zone_check)
 	if(!user || !target) return 0
@@ -886,7 +868,6 @@ var/global/image/busy_indicator_hostile
 
 	user.action_busy = FALSE
 
-
 /proc/do_after(mob/user, delay, needhand = TRUE, numticks = 5, show_busy_icon, selected_zone_check) //hacky, will suffice for now.
 	if(!istype(user) || delay <= 0) r_FAL
 
@@ -935,7 +916,6 @@ var/global/image/busy_indicator_hostile
 		user.overlays -= busy_icon
 
 	user.action_busy = FALSE
-
 
 //Takes: Anything that could possibly have variables and a varname to check.
 //Returns: 1 if found, 0 if not.
@@ -1065,11 +1045,9 @@ var/global/image/busy_indicator_hostile
 						if(!nextturf || !istype(nextturf, /turf/open/space))
 							nextturf = get_step(corner, turn(direction, 180))
 
-
 						// Take on the icon of a neighboring scrolling space icon
 						X.icon = nextturf.icon
 						X.icon_state = nextturf.icon_state
-
 
 					for(var/obj/O in T)
 						// Reset the shuttle corners
@@ -1122,7 +1100,7 @@ var/global/image/busy_indicator_hostile
 			else
 				air_master.tiles_to_update += T2*/
 
-proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
+/proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 	if(!original)
 		return null
 
@@ -1139,7 +1117,6 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 				if(!(V in list("type","loc","locs","vars", "parent", "parent_type","verbs","ckey","key")))
 					O.vars[V] = original.vars[V]
 	return O
-
 
 /area/proc/copy_contents_to(var/area/A , var/platingRequired = 0 )
 	//Takes: Area. Optional: If it should copy to areas that don't have plating
@@ -1185,7 +1162,6 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 
 	var/copiedobjs = list()
 
-
 	moving:
 		for (var/turf/T in refined_src)
 			var/datum/coords/C_src = refined_src[T]
@@ -1206,7 +1182,6 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 					X.icon_state = old_icon_state1
 					X.icon = old_icon1 //Shuttle floors are in shuttle.dmi while the defaults are floors.dmi
 
-
 					var/list/objs = new/list()
 					var/list/newobjs = new/list()
 					var/list/mobs = new/list()
@@ -1219,10 +1194,8 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 
 						objs += O
 
-
 					for(var/obj/O in objs)
 						newobjs += DuplicateObject(O , 1)
-
 
 					for(var/obj/O in newobjs)
 						O.loc = X
@@ -1241,8 +1214,6 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 					copiedobjs += newobjs
 					copiedobjs += newmobs
 
-
-
 					for(var/V in T.vars)
 						if(!(V in list("type","loc","locs","vars", "parent", "parent_type","verbs","ckey","key","x","y","z","contents", "luminosity")))
 							X.vars[V] = T.vars[V]
@@ -1259,18 +1230,15 @@ proc/DuplicateObject(obj/original, var/perfectcopy = 0 , var/sameloc = 0)
 					refined_trg -= B
 					continue moving
 
-
 	return copiedobjs
 
-
-
-proc/get_cardinal_dir(atom/A, atom/B)
+/proc/get_cardinal_dir(atom/A, atom/B)
 	var/dx = abs(B.x - A.x)
 	var/dy = abs(B.y - A.y)
 	return get_dir(A, B) & (rand() * (dx+dy) < dy ? 3 : 12)
 
 //I dont understand the above proc so I'm writing my own shittier one
-proc/get_cardinal_dir2(var/atom/A, var/atom/B)
+/proc/get_cardinal_dir2(var/atom/A, var/atom/B)
 	var/dx = B.x - A.x
 	var/dy = B.y - A.y
 	if(abs(dx) > abs(dy))
@@ -1278,17 +1246,17 @@ proc/get_cardinal_dir2(var/atom/A, var/atom/B)
 	return (dy > 0) ? NORTH : SOUTH
 
 //Returns the 2 dirs perpendicular to the arg
-proc/get_perpen_dir(var/dir)
+/proc/get_perpen_dir(var/dir)
 	if(dir & (dir-1)) return 0 //diagonals
 	if(dir in list(EAST, WEST))
 		return list(SOUTH, NORTH)
 	else return list(EAST, WEST)
 
 //chances are 1:value. anyprob(1) will always return true
-proc/anyprob(value)
+/proc/anyprob(value)
 	return (rand(1,value)==value)
 
-proc/view_or_range(distance = world.view , center = usr , type)
+/proc/view_or_range(distance = world.view , center = usr , type)
 	switch(type)
 		if("view")
 			. = view(distance,center)
@@ -1296,7 +1264,7 @@ proc/view_or_range(distance = world.view , center = usr , type)
 			. = range(distance,center)
 	return
 
-proc/oview_or_orange(distance = world.view , center = usr , type)
+/proc/oview_or_orange(distance = world.view , center = usr , type)
 	switch(type)
 		if("view")
 			. = oview(distance,center)
@@ -1304,13 +1272,12 @@ proc/oview_or_orange(distance = world.view , center = usr , type)
 			. = orange(distance,center)
 	return
 
-proc/get_mob_with_client_list()
+/proc/get_mob_with_client_list()
 	var/list/mobs = list()
 	for(var/mob/M in mob_list)
 		if (M.client)
 			mobs += M
 	return mobs
-
 
 /proc/parse_zone(zone)
 	if(zone == "r_hand") return "right hand"
@@ -1336,7 +1303,6 @@ proc/get_mob_with_client_list()
 
 /proc/get_turf_or_move(turf/location)
 	return get_turf(location)
-
 
 //Quick type checks for some tools
 var/global/list/common_tools = list(
@@ -1393,7 +1359,7 @@ var/global/list/common_tools = list(
 		return 1
 	return 0
 
-proc/is_hot(obj/item/I)
+/proc/is_hot(obj/item/I)
 	return I.heat_source
 
 //Whether or not the given item counts as sharp in terms of dealing damage
@@ -1428,9 +1394,6 @@ proc/is_hot(obj/item/I)
 	istype(W, /obj/item/tool/surgery/bonesetter)
 	)
 
-
-
-
 /proc/reverse_direction(direction)
 	switch(direction)
 		if(NORTH)
@@ -1460,7 +1423,6 @@ proc/is_hot(obj/item/I)
 		if(SOUTHWEST) 	. = list(NORTHEAST, NORTH,     EAST)
 		if(WEST) 		. = list(EAST,      NORTHEAST, SOUTHEAST)
 		if(NORTHWEST) 	. = list(SOUTHEAST, SOUTH,     EAST)
-
 
 /*
 Checks if that loc and dir has a item on the wall
@@ -1496,7 +1458,6 @@ var/list/WALLITEMS = list(
 					if(EAST)
 						if(O.pixel_x < -10)
 							return 1
-
 
 	//Some stuff is placed directly on the wallturf (signs)
 	for(var/obj/O in get_step(loc, dir))
@@ -1589,7 +1550,6 @@ var/list/WALLITEMS = list(
 		else
 			cur_x += dx2
 			cur_y += dy2
-
 
 	return turfs
 

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -17,7 +17,6 @@
 /area/Adjacent(var/atom/neighbor)
 	CRASH("Call to /area/Adjacent(), unimplemented proc")
 
-
 /*
 	Adjacency (to turf):
 	* If you are in the same turf, always true
@@ -110,7 +109,6 @@ Quick adjacency (to turf):
 		BOD.throwpass = 0
 		return .
 	return ..()
-
 
 /*
 	This checks if you there is uninterrupted airspace between that turf and this one.

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -52,7 +52,6 @@
 
 	next_move = world.time + 9
 
-
 	A.add_hiddenprint(src)
 	A.attack_ai(src)
 	return 1

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -19,7 +19,6 @@
 	if (control)	// No .click macros allowed
 		return usr.do_click(A, location, params)
 
-
 /mob/proc/do_click(atom/A, location, params)
 	// No clicking on atoms with the NOINTERACT flag
 	if ((A.flags_atom & NOINTERACT))
@@ -116,7 +115,6 @@
 
 	RangedAttack(A, mods)
 	return
-
 
 /*	OLD DESCRIPTION
 	Standard mob ClickOn()
@@ -271,12 +269,7 @@
 		buckled.dir = direction
 		buckled.handle_rotation()
 
-
-
-
-
 // click catcher stuff
-
 
 /obj/screen/click_catcher
 	icon = 'icons/mob/screen1.dmi'
@@ -286,7 +279,6 @@
 	mouse_opacity = 2
 	screen_loc = "CENTER-7,CENTER-7"
 	flags_atom = NOINTERACT
-
 
 /obj/screen/click_catcher/proc/UpdateGreed(view_size_x = 15, view_size_y = 15)
 	var/icon/newicon = icon('icons/mob/screen1.dmi', "catcher")
@@ -302,8 +294,6 @@
 	var/matrix/M = new
 	M.Scale(px/sx, py/sy)
 	transform = M
-
-
 
 /client/proc/change_view(new_size)
 	view = new_size
@@ -333,7 +323,6 @@
 	tX = Clamp(origin.x + text2num(tX) - round(actual_view[1] / 2) - 1, 1, world.maxx)
 	tY = Clamp(origin.y + text2num(tY) - round(actual_view[2] / 2) - 1, 1, world.maxy)
 	return locate(tX, tY, tZ)
-
 
 /proc/getviewsize(view)
 	var/viewX

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -30,7 +30,6 @@
 		if (!A.BorgAltClick(src))
 			return 1
 
-
 	if(aiCamera.in_camera_mode)
 		aiCamera.camera_mode_off()
 		if(is_component_functioning("camera"))
@@ -87,8 +86,6 @@
 			return 1
 	return 0
 
-
-
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
 
@@ -103,7 +100,6 @@
 
 /obj/machinery/door/airlock/BorgShiftClick()  // Opens and closes doors! Forwards to AI code.
 	AIShiftClick()
-
 
 /atom/proc/BorgCtrlClick(var/mob/living/silicon/robot/user) //forward to human click if not overriden
 	return 1

--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -13,7 +13,6 @@
 	Therefore, the top right corner (except during admin shenanigans) is at "15,15"
 */
 
-
 //Lower left, persistant menu
 #define ui_inventory "WEST:6,1:5"
 

--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -9,7 +9,6 @@
 	static_inventory += using
 	action_intent = using
 
-
 	using = new /obj/screen/mov_intent()
 	using.icon = 'icons/mob/screen1_alien.dmi'
 	using.icon_state = (owner.m_intent == MOVE_INTENT_RUN ? "running" : "walking")
@@ -61,7 +60,6 @@
 	using.layer = HUD_LAYER
 	static_inventory += using
 
-
 	using = new /obj/screen/resist/alien()
 	hotkeybuttons += using
 
@@ -95,8 +93,6 @@
 	zone_sel.update_icon(owner)
 	static_inventory += zone_sel
 
-
-
 /datum/hud/alien/persistant_inventory_update()
 	if(!mymob)
 		return
@@ -113,7 +109,6 @@
 			H.r_hand.screen_loc = null
 		if(H.l_hand)
 			H.l_hand.screen_loc = null
-
 
 /mob/living/carbon/Xenomorph/create_hud()
 	if(client && !hud_used)

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -17,8 +17,6 @@
 	locate_leader = new /obj/screen/queen_locator()
 	infodisplay += locate_leader
 
-
-
 /mob/living/carbon/Xenomorph/Larva/create_hud()
 	if(client && !hud_used)
 		hud_used = new /datum/hud/larva(src)

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -1,5 +1,3 @@
-
-
 /mob
 	var/list/fullscreens = list()
 
@@ -40,11 +38,9 @@
 		client.screen -= FS
 	cdel(FS)
 
-
 /mob/proc/clear_fullscreens()
 	for(var/category in fullscreens)
 		clear_fullscreen(category)
-
 
 /mob/proc/hide_fullscreens()
 	if(client)
@@ -57,8 +53,6 @@
 			var/obj/screen/fullscreen/FS = fullscreens[category]
 			FS.update_for_view(client.view)
 			client.screen |= fullscreens[category]
-
-
 
 /obj/screen/fullscreen
 	icon = 'icons/mob/screen1_full.dmi'
@@ -74,13 +68,11 @@
 	severity = 0
 	return TA_REVIVE_ME
 
-
 /obj/screen/fullscreen/proc/update_for_view(client_view)
 	if (screen_loc == "CENTER-7,CENTER-7" && fs_view != client_view)
 		var/list/actualview = getviewsize(client_view)
 		fs_view = client_view
 		transform = matrix(actualview[1]/15, 0, 0, 0, actualview[2]/15, 0)
-
 
 /obj/screen/fullscreen/brute
 	icon_state = "brutedamageoverlay"
@@ -140,8 +132,6 @@
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "meson_hud"
 
-
 /obj/screen/fullscreen/pain
 	icon_state = "painoverlay"
 	layer = FULLSCREEN_PAIN_LAYER
-

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -56,7 +56,6 @@
 	var/obj/screen/action_button/hide_toggle/hide_actions_toggle
 	var/action_buttons_hidden = 0
 
-
 /datum/hud/New(mob/owner)
 	mymob = owner
 	hide_actions_toggle = new
@@ -120,10 +119,8 @@
 
 	. = ..()
 
-
 /mob/proc/create_hud()
 	return
-
 
 //Version denotes which style should be displayed. blank or 0 means "next version"
 /datum/hud/proc/show_hud(version = 0)
@@ -192,8 +189,6 @@
 	mymob.update_action_buttons(TRUE)
 	mymob.reload_fullscreens()
 
-
-
 /datum/hud/human/show_hud(version = 0)
 	..()
 	hidden_inventory_update()
@@ -203,9 +198,6 @@
 
 /datum/hud/proc/persistant_inventory_update()
 	return
-
-
-
 
 //Triggered when F12 is pressed (Unless someone changed something in the DMF)
 /mob/verb/button_pressed_F12()

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -54,8 +54,6 @@
 		static_inventory += using
 		action_intent = using
 
-
-
 	if(hud_data.has_m_intent)
 		using = new /obj/screen/mov_intent()
 		using.icon = ui_style
@@ -155,12 +153,10 @@
 		pull_icon.update_icon(owner)
 		hotkeybuttons += pull_icon
 
-
 	if(hud_data.has_internals)
 		internals = new /obj/screen/internals()
 		internals.icon = ui_style
 		infodisplay += internals
-
 
 	if(hud_data.has_warnings)
 		oxygen_icon = new /obj/screen/oxygen()
@@ -194,7 +190,6 @@
 		bodytemp_icon = new /obj/screen/bodytemp()
 		bodytemp_icon.icon = ui_style
 		infodisplay += bodytemp_icon
-
 
 	if(hud_data.has_nutrition)
 		nutrition_icon = new /obj/screen()
@@ -281,8 +276,6 @@
 	gun_run_icon.update_icon(owner)
 	static_inventory += gun_run_icon
 
-
-
 /mob/living/carbon/human/verb/toggle_hotkey_verbs()
 	set category = "OOC"
 	set name = "Toggle hotkey buttons"
@@ -295,7 +288,6 @@
 		client.screen -= hud_used.hotkeybuttons
 		hud_used.hotkey_ui_hidden = 1
 
-
 //Used for new human mobs created by cloning/goleming/etc.
 /mob/living/carbon/human/proc/set_cloned_appearance()
 	f_style = "Shaved"
@@ -307,8 +299,6 @@
 	else
 		underwear = underwear_f.Find("None")
 	regenerate_icons()
-
-
 
 /datum/hud/human/hidden_inventory_update()
 	if(!mymob) return
@@ -359,7 +349,6 @@
 		if(H.head)
 			H.head.screen_loc = null
 
-
 /datum/hud/human/persistant_inventory_update()
 	if(!mymob) return
 	var/mob/living/carbon/human/H = mymob
@@ -409,8 +398,6 @@
 			H.r_hand.screen_loc = null
 		if(H.l_hand)
 			H.l_hand.screen_loc = null
-
-
 
 /mob/living/carbon/human/create_hud()
 	if(client && !hud_used)

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -83,7 +83,6 @@
 	inv_box.layer = HUD_LAYER
 	static_inventory += inv_box
 
-
 	throw_icon = new /obj/screen/throw_catch()
 	throw_icon.icon = ui_style
 	hotkeybuttons += throw_icon
@@ -154,11 +153,6 @@
 	gun_run_icon.update_icon(owner)
 	static_inventory +=	gun_run_icon
 
-
-
-
-
-
 /datum/hud/monkey/persistant_inventory_update()
 	if(!mymob)
 		return
@@ -177,7 +171,6 @@
 		if(M.wear_mask)
 			M.wear_mask.screen_loc = null
 
-
 	if(hud_version != HUD_STYLE_NOHUD)
 		if(M.r_hand)
 			M.r_hand.screen_loc = ui_rhand
@@ -190,8 +183,6 @@
 			M.r_hand.screen_loc = null
 		if(M.l_hand)
 			M.l_hand.screen_loc = null
-
-
 
 /mob/living/carbon/monkey/create_hud()
 	if(client && !hud_used)

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -4,11 +4,9 @@
 /datum/hud/ai/New(mob/living/silicon/ai/owner)
 	..()
 
-
 /mob/living/silicon/ai/create_hud()
 	if(client && !hud_used)
 		hud_used = new /datum/hud/ai(src)
-
 
 //BRAIN
 
@@ -18,7 +16,6 @@
 /mob/living/brain/create_hud()
 	if(client && !hud_used)
 		hud_used = new /datum/hud/brain(src)
-
 
 //HELLHOUND
 

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -2,7 +2,7 @@
 	..()
 	var/obj/screen/using
 
-//Radio
+	//Radio
 	using = new /obj/screen()
 	using.name = "radio"
 	using.dir = SOUTHWEST
@@ -12,7 +12,7 @@
 	using.layer = ABOVE_HUD_LAYER
 	static_inventory += using
 
-//Module select
+	//Module select
 
 	using = new /obj/screen()
 	using.name = "module1"
@@ -44,16 +44,16 @@
 	owner.inv3 = using
 	static_inventory += using
 
-//End of module select
+	//End of module select
 
-//Intent
+	//Intent
 	using = new /obj/screen/act_intent()
 	using.icon = 'icons/mob/screen1_robot.dmi'
 	using.icon_state = "intent_"+owner.a_intent
 	static_inventory += using
 	action_intent = using
 
-//Cell
+	//Cell
 	owner.cells = new /obj/screen()
 	owner.cells.icon = 'icons/mob/screen1_robot.dmi'
 	owner.cells.icon_state = "charge-empty"
@@ -61,11 +61,11 @@
 	owner.cells.screen_loc = ui_toxin
 	infodisplay += owner.cells
 
-//Health
+	//Health
 	healths = new /obj/screen/healths/robot()
 	infodisplay += healths
 
-//Installed Module
+	//Installed Module
 	owner.hands = new /obj/screen()
 	owner.hands.icon = 'icons/mob/screen1_robot.dmi'
 	owner.hands.icon_state = "nomod"
@@ -73,7 +73,7 @@
 	owner.hands.screen_loc = ui_borg_module
 	static_inventory += owner.hands
 
-//Module Panel
+	//Module Panel
 	using = new /obj/screen()
 	using.name = "panel"
 	using.icon = 'icons/mob/screen1_robot.dmi'
@@ -82,7 +82,7 @@
 	using.layer = HUD_LAYER
 	static_inventory += using
 
-//Store
+	//Store
 	module_store_icon = new /obj/screen()
 	module_store_icon.icon = 'icons/mob/screen1_robot.dmi'
 	module_store_icon.icon_state = "store"
@@ -90,7 +90,7 @@
 	module_store_icon.screen_loc = ui_borg_store
 	static_inventory += module_store_icon
 
-//Temp
+	//Temp
 	bodytemp_icon = new /obj/screen/bodytemp()
 	bodytemp_icon.screen_loc = ui_borg_temp
 	infodisplay += bodytemp_icon
@@ -129,13 +129,9 @@
 	gun_run_icon.update_icon(owner)
 	static_inventory +=	gun_run_icon
 
-
-
 /mob/living/silicon/robot/create_hud()
 	if(client && !hud_used)
 		hud_used = new /datum/hud/robot(src)
-
-
 
 /datum/hud/robot/persistant_inventory_update()
 	if(!mymob)

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -33,11 +33,9 @@
 /obj/screen/inventory
 	var/slot_id	//The indentifier for the slot. It has nothing to do with ID cards.
 
-
 /obj/screen/close
 	name = "close"
 	icon_state = "x"
-
 
 /obj/screen/close/clicked(var/mob/user)
 	if(master)
@@ -45,7 +43,6 @@
 			var/obj/item/storage/S = master
 			S.close(user)
 	return 1
-
 
 /obj/screen/action_button
 	icon = 'icons/mob/actions.dmi'
@@ -76,8 +73,6 @@
 	var/coord_row_offset = 26
 	return "WEST[coord_col]:[coord_col_offset],NORTH[coord_row]:[coord_row_offset]"
 
-
-
 /obj/screen/action_button/hide_toggle
 	name = "Hide Buttons"
 	icon = 'icons/mob/actions.dmi'
@@ -96,10 +91,8 @@
 	user.update_action_buttons()
 	return 1
 
-
 /obj/screen/storage
 	name = "storage"
-
 
 /obj/screen/storage/proc/update_fullness(obj/item/storage/S)
 	if(!S.contents.len)
@@ -114,8 +107,6 @@
 			if(7 to 9) color = "#ffa500"
 			else color = null
 
-
-
 /obj/screen/gun
 	name = "gun"
 	dir = 2
@@ -126,17 +117,17 @@
 	icon_state = "no_walk0"
 	screen_loc = ui_gun2
 
-	update_icon(mob/user)
-		if(user.gun_mode)
-			if(user.target_can_move)
-				icon_state = "no_walk1"
-				name = "Disallow Walking"
-			else
-				icon_state = "no_walk0"
-				name = "Allow Walking"
-			screen_loc = initial(screen_loc)
-			return
-		screen_loc = null
+/obj/screen/gun/move/update_icon(mob/user)
+	if(user.gun_mode)
+		if(user.target_can_move)
+			icon_state = "no_walk1"
+			name = "Disallow Walking"
+		else
+			icon_state = "no_walk0"
+			name = "Allow Walking"
+		screen_loc = initial(screen_loc)
+		return
+	screen_loc = null
 
 /obj/screen/gun/move/clicked(var/mob/user)
 	if (..())
@@ -151,24 +142,23 @@
 	gun_click_time = world.time
 	return 1
 
-
 /obj/screen/gun/run
 	name = "Allow Running"
 	icon_state = "no_run0"
 	screen_loc = ui_gun3
 
-	update_icon(mob/user)
-		if(user.gun_mode)
-			if(user.target_can_move)
-				if(user.target_can_run)
-					icon_state = "no_run1"
-					name = "Disallow Running"
-				else
-					icon_state = "no_run0"
-					name = "Allow Running"
-				screen_loc = initial(screen_loc)
-				return
-		screen_loc = null
+/obj/screen/gun/run/update_icon(mob/user)
+	if(user.gun_mode)
+		if(user.target_can_move)
+			if(user.target_can_run)
+				icon_state = "no_run1"
+				name = "Disallow Running"
+			else
+				icon_state = "no_run0"
+				name = "Allow Running"
+			screen_loc = initial(screen_loc)
+			return
+	screen_loc = null
 
 /obj/screen/gun/run/clicked(var/mob/user)
 	if (..())
@@ -183,23 +173,22 @@
 	gun_click_time = world.time
 	return 1
 
-
 /obj/screen/gun/item
 	name = "Allow Item Use"
 	icon_state = "no_item0"
 	screen_loc = ui_gun1
 
-	update_icon(mob/user)
-		if(user.gun_mode)
-			if(user.target_can_click)
-				icon_state = "no_item1"
-				name = "Allow Item Use"
-			else
-				icon_state = "no_item0"
-				name = "Disallow Item Use"
-			screen_loc = initial(screen_loc)
-			return
-		screen_loc = null
+/obj/screen/gun/item/update_icon(mob/user)
+	if(user.gun_mode)
+		if(user.target_can_click)
+			icon_state = "no_item1"
+			name = "Allow Item Use"
+		else
+			icon_state = "no_item0"
+			name = "Disallow Item Use"
+		screen_loc = initial(screen_loc)
+		return
+	screen_loc = null
 
 /obj/screen/gun/item/clicked(var/mob/user)
 	if (..())
@@ -214,22 +203,20 @@
 	gun_click_time = world.time
 	return 1
 
-
 /obj/screen/gun/mode
 	name = "Toggle Gun Mode"
 	icon_state = "gun0"
 	screen_loc = ui_gun_select
 
-	update_icon(mob/user)
-		if(user.gun_mode) icon_state = "gun1"
-		else icon_state = "gun0"
+/obj/screen/gun/mode/update_icon(mob/user)
+	if(user.gun_mode) icon_state = "gun1"
+	else icon_state = "gun0"
 
 /obj/screen/gun/mode/clicked(var/mob/user)
 	if (..())
 		return 1
 	user.ToggleGunMode()
 	return 1
-
 
 /obj/screen/zone_sel
 	name = "damage zone"
@@ -305,18 +292,11 @@
 		update_icon(user)
 	return 1
 
-
 /obj/screen/zone_sel/alien
 	icon = 'icons/mob/screen1_alien.dmi'
 
 /obj/screen/zone_sel/robot
 	icon = 'icons/mob/screen1_robot.dmi'
-
-
-
-
-
-
 
 /obj/screen/clicked(var/mob/user)
 	if(!user)	return 1
@@ -403,7 +383,6 @@
 
 	return 0
 
-
 /obj/screen/inventory/clicked(var/mob/user)
 	if (..())
 		return 1
@@ -438,10 +417,6 @@
 				return 1
 	return 0
 
-
-
-
-
 /obj/screen/throw_catch
 	name = "throw/catch"
 	icon = 'icons/mob/screen1_Midnight.dmi'
@@ -465,7 +440,6 @@
 	user.drop_item_v()
 	return 1
 
-
 /obj/screen/resist
 	name = "resist"
 	icon = 'icons/mob/screen1_Midnight.dmi'
@@ -482,7 +456,6 @@
 /obj/screen/resist/alien
 	icon = 'icons/mob/screen1_alien.dmi'
 	screen_loc = ui_storage2
-
 
 /obj/screen/mov_intent
 	name = "run/walk toggle"
@@ -511,7 +484,6 @@
 		user.update_icons()
 	return 1
 
-
 /obj/screen/act_intent
 	name = "intent"
 	icon_state = "intent_help"
@@ -538,7 +510,6 @@
 		user.a_intent_change("disarm")
 
 	return 1
-
 
 /obj/screen/internals
 	name = "toggle internals"
@@ -609,14 +580,11 @@
 						C << "<span class='notice'>You are now running on internals from [tankcheck[best]] on your [nicename[best]].</span>"
 						C.internal = tankcheck[best]
 
-
 					if(C.internal)
 						icon_state = "internal1"
 					else
 						C << "<span class='notice'>You don't have a[breathes=="oxygen" ? "n oxygen" : addtext(" ",breathes)] tank.</span>"
 	return 1
-
-
 
 /obj/screen/healths
 	name = "health"
@@ -631,8 +599,6 @@
 /obj/screen/healths/robot
 	icon = 'icons/mob/screen1_robot.dmi'
 	screen_loc = ui_borg_health
-
-
 
 /obj/screen/pull
 	name = "stop pulling"
@@ -653,8 +619,6 @@
 	else
 		icon_state = "pull0"
 
-
-
 /obj/screen/squad_leader_locator
 	icon = 'icons/mob/screen1_Midnight.dmi'
 	icon_state = "trackoff"
@@ -668,7 +632,6 @@
 	icon_state = "trackoff"
 	name = "queen locator"
 	screen_loc = ui_queen_locator
-
 
 /obj/screen/xenonightvision
 	icon = 'icons/mob/screen1_alien.dmi'
@@ -688,7 +651,6 @@
 		icon_state = "nightvision1"
 	return 1
 
-
 /obj/screen/bodytemp
 	name = "body temperature"
 	icon_state = "temp0"
@@ -703,7 +665,6 @@
 	name = "fire"
 	icon_state = "fire0"
 	screen_loc = ui_fire
-
 
 /obj/screen/toggle_inv
 	name = "toggle"

--- a/code/_onclick/human.dm
+++ b/code/_onclick/human.dm
@@ -23,7 +23,6 @@
 		H << "\red You can't bite your hand again yet..."
 		return
 
-
 	if (!H.handcuffed) return
 	if (H.a_intent != "hurt") return
 	if (H.zone_selected != "mouth") return
@@ -44,7 +43,6 @@
 	last_chew = world.time
 
 /mob/living/carbon/human/UnarmedAttack(var/atom/A, var/proximity)
-
 	if(lying) //No attacks while laying down
 		return 0
 
@@ -64,7 +62,6 @@
 	A.attack_hand(src)
 
 /mob/living/carbon/human/RangedAttack(var/atom/A)
-
 	if(!gloves && !mutations.len) return
 	var/obj/item/clothing/gloves/G = gloves
 	if((LASER in mutations) && a_intent == "hurt")

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -17,12 +17,10 @@
 	if(istype(I) && ismob(user))
 		I.attack(src, user)
 
-
 // Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
 // Click parameters is the params string from byond Click() code, see that documentation.
 /obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	return
-
 
 /obj/item/proc/attack(mob/living/M, mob/living/user, def_zone)
 	if(flags_item & NOBLUDGEON)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -14,7 +14,6 @@
 
 	return ..()
 
-
 /*
 	Animals & All Unspecified
 */
@@ -23,8 +22,6 @@
 
 /atom/proc/attack_animal(mob/user as mob)
 	return
-
-
 
 /*
 	Monkeys
@@ -67,8 +64,6 @@
 */
 /mob/new_player/click()
 	return 1
-
-
 
 /*
 	Hell Hound

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -48,7 +48,6 @@ var/const/tk_maxrange = 15
 		warning("Strange attack_tk(): TK([TK in user.mutations]) empty hand([!user.get_active_hand()])")
 	return
 
-
 /mob/attack_tk(mob/user)
 	return // needs more thinking about
 
@@ -75,113 +74,103 @@ var/const/tk_maxrange = 15
 	var/atom/movable/focus = null
 	var/mob/living/host = null
 
+/obj/item/tk_grab/dropped(mob/user)
+	if(focus && user && loc != user && loc != user.loc) // drop_held_item() gets called when you tk-attack a table/closet with an item
+		if(focus.Adjacent(loc))
+			focus.loc = loc
+	..()
 
-	dropped(mob/user)
-		if(focus && user && loc != user && loc != user.loc) // drop_held_item() gets called when you tk-attack a table/closet with an item
-			if(focus.Adjacent(loc))
-				focus.loc = loc
-		..()
+//stops TK grabs being equipped anywhere but into hands
+/obj/item/tk_grab/equipped(var/mob/user, var/slot)
+	if( (slot == WEAR_L_HAND) || (slot== WEAR_R_HAND) )	return
+	if(!disposed)
+		cdel(src)
 
+/obj/item/tk_grab/attack_self(mob/user as mob)
+	if(focus)
+		focus.attack_self_tk(user)
 
+/obj/item/tk_grab/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity)//TODO: go over this
+	if(!target || !user)	return
+	if(last_throw+3 > world.time)	return
+	if(!host || host != user)
+		cdel(src)
+		return
+	if(!(TK in host.mutations))
+		cdel(src)
+		return
+	if(isobj(target) && !isturf(target.loc))
+		return
 
-	//stops TK grabs being equipped anywhere but into hands
-	equipped(var/mob/user, var/slot)
-		if( (slot == WEAR_L_HAND) || (slot== WEAR_R_HAND) )	return
-		if(!disposed)
-			cdel(src)
-
-
-
-	attack_self(mob/user as mob)
-		if(focus)
-			focus.attack_self_tk(user)
-
-	afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity)//TODO: go over this
-		if(!target || !user)	return
-		if(last_throw+3 > world.time)	return
-		if(!host || host != user)
-			cdel(src)
-			return
-		if(!(TK in host.mutations))
-			cdel(src)
-			return
-		if(isobj(target) && !isturf(target.loc))
-			return
-
-		var/d = get_dist(user, target)
-		if(focus) d = max(d,get_dist(user,focus)) // whichever is further
-		switch(d)
-			if(0)
-				;
-			if(1 to 5) // not adjacent may mean blocked by window
-				if(!proximity)
-					user.next_move += 2
-			if(5 to 7)
-				user.next_move += 5
-			if(8 to tk_maxrange)
-				user.next_move += 10
-			else
-				user << "\blue Your mind won't reach that far."
-				return
-
-		if(!focus)
-			focus_object(target, user)
-			return
-
-		if(target == focus)
-			target.attack_self_tk(user)
-			return // todo: something like attack_self not laden with assumptions inherent to attack_self
-
-
-		if(!istype(target, /turf) && istype(focus,/obj/item) && target.Adjacent(focus))
-			var/obj/item/I = focus
-			var/resolved = target.attackby(I, user, user:get_limbzone_target())
-			if(!resolved && target && I)
-				I.afterattack(target,user,1) // for splashing with beakers
-
-
+	var/d = get_dist(user, target)
+	if(focus) d = max(d,get_dist(user,focus)) // whichever is further
+	switch(d)
+		if(0)
+			;
+		if(1 to 5) // not adjacent may mean blocked by window
+			if(!proximity)
+				user.next_move += 2
+		if(5 to 7)
+			user.next_move += 5
+		if(8 to tk_maxrange)
+			user.next_move += 10
 		else
-			apply_focus_overlay()
-			focus.throw_at(target, 10, 1, user)
-			last_throw = world.time
-		return
-
-	attack(mob/living/M as mob, mob/living/user as mob, def_zone)
-		return
-
-
-	proc/focus_object(var/obj/target, var/mob/living/user)
-		if(!istype(target,/obj))	return//Cant throw non objects atm might let it do mobs later
-		if(target.anchored || !isturf(target.loc))
-			cdel(src)
+			user << "\blue Your mind won't reach that far."
 			return
-		focus = target
-		update_icon()
+
+	if(!focus)
+		focus_object(target, user)
+		return
+
+	if(target == focus)
+		target.attack_self_tk(user)
+		return // todo: something like attack_self not laden with assumptions inherent to attack_self
+
+	if(!istype(target, /turf) && istype(focus,/obj/item) && target.Adjacent(focus))
+		var/obj/item/I = focus
+		var/resolved = target.attackby(I, user, user:get_limbzone_target())
+		if(!resolved && target && I)
+			I.afterattack(target,user,1) // for splashing with beakers
+
+	else
 		apply_focus_overlay()
+		focus.throw_at(target, 10, 1, user)
+		last_throw = world.time
+	return
+
+/obj/item/tk_grab/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
+	return
+
+/obj/item/tk_grab/proc/focus_object(var/obj/target, var/mob/living/user)
+	if(!istype(target,/obj))	return//Cant throw non objects atm might let it do mobs later
+	if(target.anchored || !isturf(target.loc))
+		cdel(src)
 		return
-
-
-	proc/apply_focus_overlay()
-		if(!focus)	return
-		var/obj/effect/overlay/O = new /obj/effect/overlay(locate(focus.x,focus.y,focus.z))
-		O.name = "sparkles"
-		O.anchored = 1
-		O.density = 0
-		O.layer = FLY_LAYER
-		O.dir = pick(cardinal)
-		O.icon = 'icons/effects/effects.dmi'
-		O.icon_state = "nothing"
-		flick("empdisable",O)
-		spawn(5)
-			cdel(O)
-		return
-
-
+	focus = target
 	update_icon()
-		overlays.Cut()
-		if(focus && focus.icon && focus.icon_state)
-			overlays += icon(focus.icon,focus.icon_state)
-		return
+	apply_focus_overlay()
+	return
+
+/obj/item/tk_grab/proc/apply_focus_overlay()
+	if(!focus)	return
+	var/obj/effect/overlay/O = new /obj/effect/overlay(locate(focus.x,focus.y,focus.z))
+	O.name = "sparkles"
+	O.anchored = 1
+	O.density = 0
+	O.layer = FLY_LAYER
+	O.dir = pick(cardinal)
+	O.icon = 'icons/effects/effects.dmi'
+	O.icon_state = "nothing"
+	flick("empdisable",O)
+	spawn(5)
+		cdel(O)
+	return
+
+/obj/item/tk_grab/update_icon()
+	overlays.Cut()
+	if(focus && focus.icon && focus.icon_state)
+		overlays += icon(focus.icon,focus.icon_state)
+	return
 
 /*Not quite done likely needs to use something thats not get_step_to
 	proc/check_path()

--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -22,7 +22,6 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 			handle_ventcrawl(A)
 		return 1
 
-
 /mob/proc/start_ventcrawl()
 	var/atom/pipe
 	var/list/pipes = list()
@@ -134,8 +133,6 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 			pipes_shown += A.pipe_vision_img
 			if(client)
 				client.images += A.pipe_vision_img
-
-
 
 /mob/living/proc/remove_ventcrawl()
 	is_ventcrawling = 0


### PR DESCRIPTION
Removed unnecessary whitespace, relocated some nested comments to be the preamble for the relevant methods, refactored absolute paths.

This is the current version of my regex for refactoring for style:
`(^([\t ]*(datum\/|proc\/|verb\/|client\/))|(^(\n){2,})|(^((datum|proc|verb|client)\s))|(\/.*\)[ ]*((\/\/).*)*(\n\s\n\s)+)|^([\t ]+(?!for|if|var)[^\(\s\.]*\([^\(\s0-9]*\/[\S ]*\)))`

edit: please note I'm currently not replacing by regex, only finding by regex.