### PR TITLE
[WIP: Balance] Squaddies get points-costing gear now

### DIFF
--- a/code/game/machinery/vending/new_marine_vendors.dm
+++ b/code/game/machinery/vending/new_marine_vendors.dm
@@ -266,6 +266,7 @@
 	name = "ColMarTech Automated Closet"
 	desc = "An automated closet hooked up to a colossal storage of standard-issue uniform and armor."
 	icon_state = "uniform_marine"
+	use_points = TRUE
 
 	vendor_role = "Squad Marine"
 
@@ -295,7 +296,23 @@
 							list("Pistol pouch", 0, /obj/item/storage/pouch/pistol, (MARINE_CAN_BUY_R_POUCH|MARINE_CAN_BUY_L_POUCH), "black"),
 							list("MASKS", 0, null, null, null),
 							list("Gas mask", 0, /obj/item/clothing/mask/gas, MARINE_CAN_BUY_MASK, "black"),
-
+							list("SPECIALTY ITEMS", 0, null, null, null),
+							list("Webbing", 30, /obj/item/clothing/tie/storage/webbing, null, "black"),
+							list("Deluxe webbing", 50, /obj/item/clothing/tie/storage/brown_vest, null, "black"), //Forever out of reach
+							list("Shotgun stock", 15, /obj/item/attachable/stock/shotgun, null, "black"),
+							list("Submachinegun stock", 15, /obj/item/attachable/stock/smg, null, "black"),
+							list("Rifle stock", 15, /obj/item/attachable/stock/rifle, null, "black"),
+							list("Vertical grip", 15, /obj/item/attachable/verticalgrip, null, "black"),
+							list("Angled grip", 15, /obj/item/attachable/angledgrip, null, "black"),
+							list("Extended barrel", 15, /obj/item/attachable/extended_barrel, null, "black"),
+							list("Red-dot sight", 15, /obj/item/attachable/reddot, null, "black"),
+							list("Recoil compensator", 20, /obj/item/attachable/compensator, null, "black"),
+							list("Quickfire adapter", 20, /obj/item/attachable/quickfire, null, "black"),
+							list("Burstfire adapter", 20, /obj/item/attachable/burstfire_assembly, null, "black"),
+							list("Laser sight", 30, /obj/item/attachable/lasersight, null, "black"),
+							list("Gyroscopic stabilizer", 30, /obj/item/attachable/gyro, null, "black"),
+							list("Barrel charger", 45, /obj/item/attachable/heavy_barrel, null, "black"),
+							list("Mini rail scope", 45, /obj/item/attachable/scope/mini, null, "black"),
 							)
 
 


### PR DESCRIPTION
Works just like the medic/smartgunner?/specialist/leader points-based item stuff.

Unfortunately, each ID having 45 points is hardcoded across ALL IDs, and I can't be bothered changing that, so costs are currently based around that.

The current list (and costs) are placeholders, but the _point_ of the whole thing is to make marines less reliant on requisitions at round-start. Because having _literally every marine_ queue up is a pain in the ass in regards to waiting, and a pain in the ass in regards to having to serve them.

Yes, I know marines need to be delayed currently so that xenos have time to set up, but we can:
1. Find a better way to occupy marines, rather than having them fight in a queue and get bitchy at requisitions, and:
2. Find a better way to accelerate xeno pre-game.

Simulating your local DMV for the point of wasting time is just dumb. We can do better. I _know_ we can. Rustled, MSO, even you, spookydonut, back on your illegally closed-source fork. I _know_ we can all do better. I _believe_ in our ability, as a community, to give people actually satisfactory gameplay without taking away meaningful decisions at roundstart. I _trust_ that we won't settle for shitty experiences when engaging, _fun_ alternatives lie just around the corner.

End the req queue! Make squadprep great again!