### PR TITLE
Makes marine weapons spawn with a flashlight

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -49,7 +49,8 @@
 		select_gamemode_skin(/obj/item/weapon/gun/pistol/m4a3)
 		..()
 		attachable_offset = list("muzzle_x" = 28, "muzzle_y" = 20,"rail_x" = 10, "rail_y" = 22, "under_x" = 21, "under_y" = 17, "stock_x" = 21, "stock_y" = 17)
-
+	starting_attachment_types = list(
+	/obj/item/attachable/flashlight)
 /obj/item/weapon/gun/pistol/m4a3/set_gun_config_values()
 	fire_delay = config.mhigh_fire_delay
 	accuracy_mult = config.base_hit_accuracy_mult + config.low_hit_accuracy_mult

--- a/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/revolvers.dm
@@ -285,7 +285,8 @@
 						/obj/item/attachable/scope,
 						/obj/item/attachable/lasersight,
 						/obj/item/attachable/scope/mini)
-
+	starting_attachment_types = list(
+						/obj/item/attachable/flashlight)
 	New()
 		..()
 		attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 21,"rail_x" = 17, "rail_y" = 23, "under_x" = 22, "under_y" = 17, "stock_x" = 22, "stock_y" = 19)

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -63,7 +63,9 @@
 						/obj/item/attachable/scope/mini)
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-	starting_attachment_types = list(/obj/item/attachable/attached_gun/grenade)
+	starting_attachment_types = list(
+						/obj/item/attachable/attached_gun/grenade,
+						/obj/item/attachable/flashlight)
 
 /obj/item/weapon/gun/rifle/m41a/New()
 	select_gamemode_skin(/obj/item/weapon/gun/rifle/m41a)

--- a/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/shotguns.dm
@@ -21,7 +21,8 @@ can cause issues with ammo types getting mixed up during the burst.
 	aim_slowdown = SLOWDOWN_ADS_SHOTGUN
 	wield_delay = WIELD_DELAY_FAST //Shotguns are really easy to put up to fire, since they are designed for CQC (at least compared to a rifle)
 	gun_skill_category = GUN_SKILL_SHOTGUNS
-
+	starting_attachment_types = list(
+	/obj/item/attachable/flashlight)
 /obj/item/weapon/gun/shotgun/New()
 	..()
 	replace_tube(current_mag.current_rounds) //Populate the chamber.
@@ -395,7 +396,8 @@ can cause issues with ammo types getting mixed up during the burst.
 						/obj/item/attachable/magnetic_harness,
 						/obj/item/attachable/attached_gun/flamer,
 						/obj/item/attachable/stock/shotgun)
-
+	starting_attachment_types = list(
+						/obj/item/attachable/flashlight)
 /obj/item/weapon/gun/shotgun/pump/New()
 	select_gamemode_skin(/obj/item/weapon/gun/shotgun/pump)
 	..()

--- a/code/modules/projectiles/updated_projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/smgs.dm
@@ -51,7 +51,8 @@
 						/obj/item/attachable/magnetic_harness)
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER
-
+	starting_attachment_types = list(
+						/obj/item/attachable/flashlight)
 /obj/item/weapon/gun/smg/m39/New()
 	select_gamemode_skin(/obj/item/weapon/gun/smg/m39, list(MAP_ICE_COLONY = "m39b2") )
 	..()


### PR DESCRIPTION
Marine weapons (M4A3, M44, M39, M37A2, M41A Mk2) now spawn with flashlights attached. This is done with the aim of reducing marine prep time, because there's no reason why you wouldn't want a flashlight on your gun if you can't get anything else