### PR TITLE
Make autoinjectors viable again

### DIFF
--- a/code/game/objects/items/reagent_containers/autoinjectors.dm
+++ b/code/game/objects/items/reagent_containers/autoinjectors.dm
@@ -9,6 +9,7 @@
 	item_state = "hypo"
 	amount_per_transfer_from_this = 15
 	volume = 15
+	w_class = 1.0
 
 /obj/item/reagent_container/hypospray/autoinjector/attack(mob/M as mob, mob/user as mob)
 	. = ..()

--- a/code/game/objects/items/storage/pouch.dm
+++ b/code/game/objects/items/storage/pouch.dm
@@ -287,7 +287,7 @@
 	name = "auto-injector pouch"
 	desc = "A pouch specifically for auto-injectors."
 	icon_state = "autoinjector"
-	storage_slots = 4
+	storage_slots = 8
 	can_hold = list(
 	    "/obj/item/reagent_container/hypospray/autoinjector"
 	)


### PR DESCRIPTION
Surrealistik was complaining on discord so I did a thing

Autoinjectors now take up half as much width (2.0 -> 1.0. The coloured bands are still visible... barely) and the medic's autoinjector pouch now takes 8 (EIGHT) autoinjectors, up from 4 (four...).

You might say "hey, eight is a lot". But that's double four, I didn't invent how math works.

I wonder at what point these PRs are gonna be considered spam.