### PR TITLE
Removing a warning for survivors to not linger around the LZ

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -649,7 +649,6 @@ datum/game_mode/proc/initialize_special_clamps()
 			else
 				to_chat(H, "\blue You are a survivor of the attack on the colony. You worked or lived in the archaeology colony, and managed to avoid the alien attacks...until now.")
 		to_chat(H, "\blue You are fully aware of the xenomorph threat and are able to use this knowledge as you see fit.")
-		to_chat(H, "\blue You are NOT aware of the marines or their intentions, and lingering around arrival zones will get you survivor-banned.")
 	return 1
 
 /datum/game_mode/proc/tell_survivor_story()

--- a/code/game/gamemodes/colonialmarines/Halloween.dm
+++ b/code/game/gamemodes/colonialmarines/Halloween.dm
@@ -157,7 +157,6 @@
 		to_chat(H, "<h2>You are a survivor!</h2>")
 		to_chat(H, "\blue You are a survivor of the attack on LV-624. You worked or lived in the archaeology colony, and managed to avoid the alien attacks.. until now.")
 		to_chat(H, "\blue You are fully aware of the xenomorph threat and are able to use this knowledge as you see fit.")
-		to_chat(H, "\blue You are NOT aware of the marines or their intentions, and lingering around arrival zones will get you survivor-banned.")
 	return 1
 
 //This is processed each tick, but check_win is only checked 5 ticks, so we don't go crazy with scanning for mobs.

--- a/code/game/gamemodes/colonialmarines/daedalus_prison.dm
+++ b/code/game/gamemodes/colonialmarines/daedalus_prison.dm
@@ -186,7 +186,6 @@
 		to_chat(H, "<h2>You are a survivor!</h2>")
 		to_chat(H, "\blue You are a survivor of the attack on the Daedalus Prison facility. You worked or lived in the prison, and managed to avoid the alien attacks.. until now.")
 		to_chat(H, "\blue You are fully aware of the xenomorph threat and are able to use this knowledge as you see fit.")
-		to_chat(H, "\blue You are NOT aware of the marines or their intentions, and lingering around arrival zones will get you survivor-banned.")
 	return 1
 
 //This is processed each tick, but check_win is only checked 5 ticks, so we don't go crazy with scanning for mobs.


### PR DESCRIPTION
This removes the "Don't linger around the LZ" Warning for survivors.