### PR TITLE
Destructible/Dismantle-able Showcases

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -261,7 +261,7 @@
 				M.coughedtime = 0
 
 	//Topical damage (acid on exposed skin)
-	to_chat(M, "<span class='danger'>Your skin feels like it is melting away!</span>")
+	M << "<span class='danger'>Your skin feels like it is melting away!</span>"
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.adjustFireLoss(amount*rand(15, 20)) //Burn damage, randomizes between various parts //Amount corresponds to upgrade level, 1 to 2.5
@@ -296,11 +296,10 @@
 	//Gas masks protect from inhalation and face contact effects, even without internals. Breath masks don't for balance reasons
 	if(!istype(M.wear_mask, /obj/item/clothing/mask/gas))
 		M.adjustOxyLoss(15) //Causes even more oxyloss damage due to neurotoxin locking up respiratory system
-		M.ear_deaf = max(M.ear_deaf, round(effect_amt*1.5)) //Paralysis of hearing system, aka deafness
-		if(!M.eye_blind) //Eye exposure damage
-			to_chat(M, "<span class='danger'>Your eyes sting. You can't see!</span>")
-		M.eye_blurry = max(M.eye_blurry, effect_amt*2)
-		M.eye_blind = max(M.eye_blind, round(effect_amt))
+		var/neurotox_target = 5 //Target neurotox number per tick
+		var/neurotox_max = neurotox_target / 2 * 1.5 //Target number is 4U, so use half that
+		var/neurotox_min = neurotox_target / 2 * 0.5
+		M.reagents.add_reagent("xeno_toxin", rand(neurotox_min,neurotox_max) + rand(neurotox_min,neurotox_max))
 		if(M.coughedtime != 1 && !M.stat) //Coughing/gasping
 			M.coughedtime = 1
 			if(prob(50))
@@ -311,7 +310,7 @@
 				M.coughedtime = 0
 
 	//Topical damage (neurotoxin on exposed skin)
-	to_chat(M, "<span class='danger'>Your body is going numb, almost as if paralyzed!</span>")
+	M << "<span class='danger'>Your body is going numb, almost as if paralyzed!</span>"
 	if(prob(40 + round(amount*15))) //Highly likely to drop items due to arms/hands seizing up
 		M.drop_held_item()
 	if(ishuman(M))
@@ -369,12 +368,3 @@
 
 /datum/effect_system/smoke_spread/xeno_weaken
 	smoke_type = /obj/effect/particle_effect/smoke/xeno_weak
-
-
-
-
-
-
-
-
-

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -120,11 +120,29 @@
 			cdel(src)
 		return
 
-proc/flame_radius(radius = 1, turf/turf) //~Art updated fire.
+proc/flame_radius(radius = 1, stacks = 20, duration = 20, turf/turf) //~Art updated fire.
 	if(!turf || !isturf(turf)) return
 	if(radius < 0) radius = 0
 	if(radius > 5) radius = 5
-	new /obj/flamer_fire(turf, 5 + rand(0,11), 15, null, radius)
+	stacks = stacks / 2 //Set up gaussian distribution of stack/duration outcomes
+	duration = duration / 2
+	var/stacks_min = stacks / 2
+	var/stacks_max = stacks * 1.5
+	var/duration_min = duration / 2
+	var/duration_max = duration * 1.5
+	var/stacks_final = rand(stacks_min, stacks_max) + rand(stacks_min, stacks_max)
+	var/duration_final = rand(duration_min, duration_max) + rand(duration_min, duration_max)
+	new /obj/flamer_fire(turf, rand(stacks_final), rand(duration_final),  null, radius)
+	for(var/mob/living/carbon/M in range(2, turf))
+		if(istype(M,/mob/living/carbon/Xenomorph))
+			var/mob/living/carbon/Xenomorph/X = M
+			if(X.fire_immune) continue
+
+		if(M.stat == DEAD) continue
+		M.adjust_fire_stacks(stacks_final)
+		M.IgniteMob()
+		M.adjustFireLoss(rand(stacks_final))
+		M.visible_message("<span class='danger'>[M] bursts into flames!</span>","[isXeno(M)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
 
 
 /obj/item/explosive/grenade/incendiary/molotov

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -5,14 +5,207 @@
 	desc = "A stand with the empty body of a cyborg bolted to it."
 	density = 1
 	anchored = 1
+	var/damage = 0
+	var/health_max = 200
+	var/soak = 5 //how much damage is reduced before affecting health
+	var/max_temperature = 1000
+	
+//create_debris creates debris like shards and rods. This also includes the window frame for explosions
+//If an user is passed, it will create a "user smashes through the window" message. AM is the item that hits
+//Please only fire this after a hit
+/obj/structure/showcase/proc/healthcheck(make_hit_sound = 1, create_debris = 1, mob/user, atom/movable/AM)
 
+	if(damage >= health_max)
+		if(user)
+			user.visible_message("<span class='danger'>[user] smashes through [src][AM ? " with [AM]":""]!</span>")
+		playsound(loc, 'sound/effects/metal_crash.ogg', 35)
+		create_debris()
+	if(make_hit_sound)
+		playsound(loc, 'sound/effects/grillehit.ogg', 25, 1)
+
+/obj/structure/showcase/proc/create_debris(var/create_debris = 1)
+	new /obj/item/stack/sheet/metal(loc)
+	if(create_debris > 1) //If it was properly dismantled, generate another stack o metal.
+		new /obj/item/stack/sheet/metal(loc)
+	cdel(src)
+
+/obj/structure/showcase/bullet_act(var/obj/item/projectile/Proj)
+	var/impact = max(0,Proj.damage - soak)
+	if(Proj.ammo.damage_type == HALLOSS || impact <= 0)
+		return 0
+
+	damage += impact
+	..()
+	healthcheck()
+	return 1
+	
 /obj/structure/showcase/ex_act(severity)
+	var/impact 
 	switch(severity)
 		if(1)
-			cdel(src)
+			cdel(src) //Nope
 		if(2)
-			if(prob(50))
-				cdel(src)
+			impact = max(0,rand(100, 300) - soak)
+			if(impact)
+				damage += impact 
+				healthcheck(0, 1)
+		if(3)
+			impact = max(0,rand(25, 100) - soak)
+			if(impact)
+				damage += impact 
+				healthcheck(0, 1)
+
+/obj/structure/showcase/hitby(AM as mob|obj)
+	..()
+	visible_message("<span class='danger'>The [src] was hit by [AM].</span>")
+	var/tforce = 0
+	if(ismob(AM))
+		tforce = 40
+	else if(isobj(AM))
+		var/obj/item/I = AM
+		tforce = I.throwforce
+	tforce -= soak
+	if(tforce)
+		damage += tforce
+		healthcheck()
+
+/obj/structure/showcase/attack_hand(mob/user as mob)
+	if(HULK in user.mutations)
+		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!"))
+		user.visible_message("<span class='danger'>[user] smashes through the [src]!</span>")
+		damage += max(0,100 - soak)
+		healthcheck(1, 1, user)
+
+	else if(ishuman(user) && user.a_intent == "hurt")
+		var/mob/living/carbon/human/H = user
+		if(H.species.can_shred(H))
+			attack_generic(H, 25)
+
+/obj/structure/showcase/attack_paw(mob/user as mob)
+	return attack_hand(user)
+
+//Used by attack_animal
+/obj/structure/showcase/proc/attack_generic(mob/living/user, impact = 0)
+	user.animation_attack_on(src)
+	user.visible_message("<span class='danger'>[user] smashes into the [src]!</span>")
+	impact -= soak
+	if(impact)
+		damage += max(impact - soak,0)
+		healthcheck(1, 1, user)
+
+/obj/structure/fence/attack_animal(mob/user as mob)
+	if(!isanimal(user)) return
+	var/mob/living/simple_animal/M = user
+	if(M.melee_damage_upper <= 0) return
+	attack_generic(M, M.melee_damage_upper)
+
+/obj/structure/showcase/attackby(obj/item/W, mob/user)
+
+	if(istype(W, /obj/item/stack/sheet/metal) && damage)
+		if(user.mind && user.mind.cm_skills && user.mind.cm_skills.construction < SKILL_CONSTRUCTION_PLASTEEL)
+			user << "<span class='warning'>You don't have the skill needed to fix the [src]'s structure."
+			return
+		var/obj/item/stack/sheet/R = W
+		var/amount_needed = 1
+		if(R.amount >= amount_needed)
+			user.visible_message("<span class='notice'>[user] starts repairing the [src] with [R].</span>",
+			"<span class='notice'>You start repairing the [src] with [R]")
+			playsound(src, 'sound/items/Ratchet.ogg', 25, 1)
+			if(do_after(user, 30, TRUE, 5, BUSY_ICON_FRIENDLY))
+				if(R.amount < amount_needed)
+					user << "<span class='warning'>You need more metal sheets to repair [src]."
+					return
+				R.use(amount_needed)
+				damage = 0
+				playsound(src, 'sound/items/Ratchet.ogg', 25, 1)
+				user.visible_message("<span class='notice'>[user] repairs [src] with [R].</span>",
+				"<span class='notice'>You repair [src] with [R]")
+				return
+		else
+			user << "<span class='warning'>You need more metal sheets to repair [src]."
+			return
+
+	if(istype(W, /obj/item/grab) && get_dist(src, user) < 2)
+		var/obj/item/grab/G = W
+		if(istype(G.grabbed_thing, /mob/living))
+			var/mob/living/M = G.grabbed_thing
+			var/state = user.grab_level
+			var/impact
+			user.drop_held_item()
+			switch(state)
+				if(GRAB_PASSIVE)
+					M.visible_message("<span class='warning'>[user] slams [M] against \the [src]!</span>")
+					M.apply_damage(7)
+				if(GRAB_AGGRESSIVE)
+					M.visible_message("<span class='danger'>[user] bashes [M] against \the [src]!</span>")
+					if(prob(50))
+						M.KnockDown(1)
+					M.apply_damage(10)
+					impact += (10 - soak)
+				if(GRAB_NECK)
+					M.visible_message("<span class='danger'><big>[user] crushes [M] against \the [src]!</big></span>")
+					M.KnockDown(5)
+					M.apply_damage(20)
+					impact += (15 - soak)
+			if(impact)
+				damage += impact
+				healthcheck(1, 1, M) //The person thrown into the showcase literally shattered it
+		return
+
+	if(W.flags_item & NOBLUDGEON) return
+
+	if(istype(W, /obj/item/tool/weldingtool))
+		var/obj/item/tool/weldingtool/WT = W
+		if(WT.remove_fuel(0, user))
+			user.visible_message("<span class='notice'>[user] starts cutting through [src] with [W].</span>",
+			"<span class='notice'>You start cutting through [src] with [W]")
+			playsound(src, 'sound/items/Welder.ogg', 25, 1)
+			if(do_after(user, max(5, round(damage / 5)), TRUE, 5, BUSY_ICON_FRIENDLY) && istype(src, /obj/structure/window_frame) && WT && WT.isOn())
+				playsound(src, 'sound/items/Welder.ogg', 25, 1)
+				user.visible_message("<span class='notice'>[user] cuts through [src] with [W].</span>",
+				"<span class='notice'>You cut apart the [src] with [W]")
+				create_debris(2)
+		else
+			user << "<span class='warning'>You need more welding fuel to complete this task.</span>"
+			return
+		return
+	if(istype(W, /obj/item/tool/wrench))
+		if(anchored)
+			user.visible_message("<span class='notice'>[user] starts loosening the [src]'s bolts with [W].</span>",
+			"<span class='notice'>You start loosening the [src]'s bolts with [W]")
+			playsound(src, 'sound/items/Ratchet.ogg', 25, 1)
+			if(do_after(user, 20, TRUE, 5, BUSY_ICON_BUILD))
+				playsound(src, 'sound/items/Ratchet.ogg', 25, 1)
+				user.visible_message("<span class='notice'>[user] loosened the [src]'s bolts with [W].</span>",
+				"<span class='notice'>You loosened the [src]'s bolts with [W]")
+				anchored = 0
+		else
+			user.visible_message("<span class='notice'>[user] starts tightening the [src]'s bolts with [W].</span>",
+			"<span class='notice'>You start tightening the [src]'s bolts with [W]")
+			playsound(src, 'sound/items/Ratchet.ogg', 25, 1)
+			if(do_after(user, 20, TRUE, 5, BUSY_ICON_BUILD))
+				playsound(src, 'sound/items/Ratchet.ogg', 25, 1)
+				user.visible_message("<span class='notice'>[user] tightened the [src]'s bolts with [W].</span>",
+				"<span class='notice'>You tightened the [src]'s bolts with [W]")
+				anchored = 1
+		return	
+	else
+		var/strike = max(0,(W.force - soak))
+		playsound(loc, 'sound/effects/clang.ogg', 25, 1)
+		if(strike)
+			damage += strike
+			healthcheck(0, 1, user, W)
+		else
+			user.visible_message("<span class='notice'>[user]'s attack with [W] bounces harmlessly off the [src].</span>",
+			"<span class='notice'>Your attack with [W] bounces harmlessly off the [src]")
+		..()
+
+/obj/structure/showcase/fire_act(exposed_temperature, exposed_volume)
+	if(exposed_temperature > max_temperature)
+		damage += round(exposed_volume / 100)
+		healthcheck(0) //Don't make hit sounds, it's dumb with fire/heat
+	..()
+
 
 /obj/structure/monorail
 	name = "monorail track"
@@ -38,15 +231,15 @@
 
 /obj/structure/mopbucket/examine(mob/user)
 	..()
-	to_chat(user, "It contains [reagents.total_volume] unit\s of water!")
+	user << "It contains [reagents.total_volume] unit\s of water!"
 
 /obj/structure/mopbucket/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/tool/mop))
 		if(reagents.total_volume < 1)
-			to_chat(user, "<span class='warning'>[src] is out of water!</span>")
+			user << "<span class='warning'>[src] is out of water!</span>"
 		else
 			reagents.trans_to(I, 5)
-			to_chat(user, "<span class='notice'>You wet [I] in [src].</span>")
+			user << "<span class='notice'>You wet [I] in [src].</span>"
 			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
 
 

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -16,12 +16,12 @@
 	set desc = "Shows whether or not a mine is contained within the xenomorph list."
 
 	if(!ticker || ticker.current_state != GAME_STATE_PLAYING || !ticker.mode)
-		to_chat(src, "<span class='warning'>The round is either not ready, or has already finished.</span>")
+		src << "<span class='warning'>The round is either not ready, or has already finished.</span>"
 		return
 	if(mind in ticker.mode.xenomorphs)
-		to_chat(src, "<span class='debuginfo'>[src] mind is in the xenomorph list. Mind key is [mind.key].</span>")
-		to_chat(src, "<span class='debuginfo'>Current mob is: [mind.current]. Original mob is: [mind.original].</span>")
-	to_chat(else src, "<span class='debuginfo'>This xenomorph is not in the xenomorph list.</span>")
+		src << "<span class='debuginfo'>[src] mind is in the xenomorph list. Mind key is [mind.key].</span>"
+		src << "<span class='debuginfo'>Current mob is: [mind.current]. Original mob is: [mind.original].</span>"
+	else src << "<span class='debuginfo'>This xenomorph is not in the xenomorph list.</span>"
 #endif
 
 #undef DEBUG_XENO
@@ -47,6 +47,8 @@
 	hand = 1 //Make right hand active by default. 0 is left hand, mob defines it as null normally
 	see_in_dark = 8
 	see_infrared = 1
+	var/critical_proc = 0
+	var/critical_delay = 30
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	hud_possible = list(HEALTH_HUD_XENO, PLASMA_HUD, PHEROMONE_HUD,QUEEN_OVERWATCH_HUD)
 	unacidable = TRUE
@@ -147,30 +149,30 @@
 /mob/living/carbon/Xenomorph/examine(mob/user)
 	..()
 	if(isXeno(user) && caste_desc)
-		to_chat(user, caste_desc)
+		user << caste_desc
 
 	if(stat == DEAD)
-		to_chat(user, "It is DEAD. Kicked the bucket. Off to that great hive in the sky.")
+		user << "It is DEAD. Kicked the bucket. Off to that great hive in the sky."
 	else if(stat == UNCONSCIOUS)
-		to_chat(user, "It quivers a bit, but barely moves.")
+		user << "It quivers a bit, but barely moves."
 	else
 		var/percent = (health / maxHealth * 100)
 		switch(percent)
 			if(95 to 101)
-				to_chat(user, "It looks quite healthy.")
+				user << "It looks quite healthy."
 			if(75 to 94)
-				to_chat(user, "It looks slightly injured.")
+				user << "It looks slightly injured."
 			if(50 to 74)
-				to_chat(user, "It looks injured.")
+				user << "It looks injured."
 			if(25 to 49)
-				to_chat(user, "It bleeds with sizzling wounds.")
+				user << "It bleeds with sizzling wounds."
 			if(1 to 24)
-				to_chat(user, "It is heavily injured and limping badly.")
+				user << "It is heavily injured and limping badly."
 
 	if(hivenumber != XENO_HIVE_NORMAL)
 		if(hivenumber && hivenumber <= hive_datum.len)
 			var/datum/hive_status/hive = hive_datum[hivenumber]
-			to_chat(user, "It appears to belong to the [hive.prefix]hive")
+			user << "It appears to belong to the [hive.prefix]hive"
 	return
 
 /mob/living/carbon/Xenomorph/Dispose()

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -80,13 +80,15 @@
 
 			//Check for a special bite attack
 			if(prob(M.bite_chance))
-				M.bite_attack(src, damage)
-				return 1
+				if(!M.critical_proc) //Can't crit if we already crit in the past 3 seconds
+					M.bite_attack(src, damage)
+					return 1
 
 			//Check for a special bite attack
 			if(prob(M.tail_chance))
-				M.tail_attack(src, damage)
-				return 1
+				if(!M.critical_proc) //Can't crit if we already crit in the past 3 seconds
+					M.tail_attack(src, damage)
+					return 1
 
 			//Somehow we will deal no damage on this attack
 			if(!damage)

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -44,6 +44,8 @@
 	var/shell_speed 				= 0 		// How fast the projectile moves
 	var/bonus_projectiles_type 					// Type path of the extra projectiles
 	var/bonus_projectiles_amount 	= 0 		// How many extra projectiles it shoots out. Works kind of like firing on burst, but all of the projectiles travel together
+	var/reagent						= ""		// Applies a specified reagent on hit
+	var/reagent_amount				= 0			// Applies a designated amoutn of reagent on hit
 	var/debilitate[]				= null 		// Stun,knockdown,knockout,irradiate,stutter,eyeblur,drowsy,agony
 
 	New()
@@ -1002,37 +1004,38 @@
 		accuracy = config.med_hit_accuracy
 		accuracy_var_low = config.low_proj_variance
 		accuracy_var_high = config.low_proj_variance
-		max_range = config.short_shell_range
 
 /datum/ammo/xeno/toxin
 	name = "neurotoxic spit"
 	damage_falloff = 0
-	debilitate = list(1,2,0,0,0,0,0,0)
+	debilitate = list(1,1,0,0,0,0,0,0)
+	reagent = "xeno_toxin"
+	reagent_amount = 3
 	flags_ammo_behavior = AMMO_XENO_TOX|AMMO_IGNORE_RESIST
 	spit_cost = 50
 
 	New()
 		..()
 		shell_speed = config.reg_shell_speed
-		max_range = config.close_shell_range
 
 /datum/ammo/xeno/toxin/medium //Spitter
 	name = "neurotoxic spatter"
-	debilitate = list(2,3,0,0,1,2,0,0)
+	reagent = "xeno_toxin"
+	reagent_amount = 5
+	debilitate = list(1,1,0,0,0,0,0,0)
 	New()
 		..()
-		shell_speed = config.fast_shell_speed
 		accuracy_var_low = config.high_proj_variance
 		accuracy_var_high = config.high_proj_variance
 
 /datum/ammo/xeno/toxin/heavy //Praetorian
 	name = "neurotoxic splash"
-	debilitate = list(3,4,0,0,3,5,0,0)
+	reagent = "xeno_toxin"
+	reagent_amount = 7
+	debilitate = list(1,1,0,0,0,0,0,0)
 
 /datum/ammo/xeno/toxin/heavy/New()
 	..()
-	max_range = config.min_shell_range
-	shell_speed = config.reg_shell_speed
 
 /datum/ammo/xeno/sticky
 	name = "sticky resin spit"

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -454,6 +454,8 @@
 	var/damage = max(0, P.damage - round(P.distance_travelled * P.ammo.damage_falloff))
 	if(P.ammo.debilitate && stat != DEAD && ( damage || (P.ammo.flags_ammo_behavior & AMMO_IGNORE_RESIST) ) )
 		apply_effects(arglist(P.ammo.debilitate))
+	if(P.ammo.reagent_amount) // Apply Xeno neurotoxin (usually; could be anything)
+		src:reagents.add_reagent(P.ammo.reagent, max(1,P.ammo.reagent_amount))
 
 	if(damage)
 		bullet_message(P)

--- a/code/modules/reagents/chemistry_reagents/other.dm
+++ b/code/modules/reagents/chemistry_reagents/other.dm
@@ -557,6 +557,43 @@
 	reagent_state = SOLID
 	color = "#A8A8A8" // rgb: 168, 168, 168
 
+/datum/reagent/xeno_neurotoxin
+	name = "Neurotoxin"
+	id = "xeno_toxin"
+	description = "A debilitating nerve toxin. Impedes motor control. Causes temporary blindness, hallucinations and deafness at higher doses."
+	reagent_state = LIQUID
+	color = "#CF3600" // rgb: 207, 54, 0
+	custom_metabolism = 0.5 // Fast meta rate.
+	overdose = REAGENTS_OVERDOSE
+	overdose_critical = REAGENTS_OVERDOSE_CRITICAL
+
+	on_mob_life(mob/living/M)
+		. = ..()
+		if(!.) return
+		if(volume > 1) //1st level neurotoxin effects: minor toxin damage, confusion, dizziness/jitteriness; note that most effects scale/accumulate with dosage
+			M.confused += (min(volume / 2))
+			M.make_dizzy(min(40,volume / 2 ))
+			M.make_jittery(min(40,volume / 2))
+			M.reagent_move_delay_modifier += volume / 2.5
+			M.adjustToxLoss(volume/10*REM)
+		if(volume > 5) //2nd level neurotoxin effects: hallucinations, drug overlay, stuttering
+			M.hallucination += volume / 2.5
+			M.druggy += volume / 2.5
+			M.stuttering += volume / 2.5
+		if(volume > 10) //3rd level neurotoxin effects: blindness, deafness
+			M.ear_deaf += volume / 5 //Paralysis of hearing system, aka deafness
+			if(!M.eye_blind) //Eye exposure damage
+				M << "<span class='danger'>Your eyes sting. You can't see!</span>"
+			M.eye_blurry += volume / 5
+			M.eye_blind += volume / 5
+
+	on_overdose(mob/living/M)
+		M.adjustBrainLoss(1) //Overdose starts applying brain damage
+
+	on_overdose_critical(mob/living/M)
+		M.adjustBrainLoss(2) //Massive brain damage
+
+
 /datum/reagent/fuel
 	name = "Welding fuel"
 	id = "fuel"


### PR DESCRIPTION
Per title.

Showcases can be damaged, including by heat, projectiles and explosions, leaving behind wreckage of 1 metal. They can be repaired with metal, and can be anchored/unanchored with a wrench.

Showcases can be dismantled for 2 metal with a welder.