### PR TITLE
Fixes jobs list not populating

### DIFF
--- a/code/game/jobs/role_authority.dm
+++ b/code/game/jobs/role_authority.dm
@@ -83,7 +83,7 @@ var/global/datum/authority/branch/role/RoleAuthority
 		J = roles_for_mode[i]
 		if(J)
 			L[J.title] = J
-		roles_for_mode = L
+	roles_for_mode = L
 
 	for(var/i in squads_all) //Setting up our squads.
 		S = new i()

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -11,6 +11,7 @@ bluenothing - Admin
 bobdobbington - Admin
 borisvanmemes - Admin
 cedarbridge - Admin
+chemicalrascal - Admin
 cheridan - Admin
 citrusgender - Admin
 cyberboss - Admin


### PR DESCRIPTION
Unfortunately @LetterN isn't descriptive in their commits so I don't know what the intent of the commit was, BUT it does fix the jobs list not populating

(Yeeeee N I'mma call you out come at me, fight me bro)

But yeah Ninja you're gonna want to test this more because while it works for Extended and Distress Call, idk enough about adminning to be able to work out the full ramifications here