### PR TITLE
Replaces CM anti-powergame toxin chems with weaker versions of their reactants.

### DIFF
--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -49,14 +49,14 @@
 
 
 /datum/chemical_reaction/hypozine
-	name = "hypozine"
+	name = "Hypozine"
 	id = "hypozine"
 	result = "hypozine"
 	required_reagents = list("hyperzine" = 1, "peridaxon" = 1)
 	result_amount = 2
 
 /datum/chemical_reaction/percocet
-	name = "percocet"
+	name = "Percocet"
 	id = "percocet"
 	result = "percocet"
 	required_reagents = list("paracetamol" = 1, "tramadol" = 1)

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -48,24 +48,24 @@
 		holder.clear_reagents()
 
 
-/datum/chemical_reaction/hptoxin
-	name = "Toxin"
-	id = "hptoxin"
-	result = "hptoxin"
+/datum/chemical_reaction/hypozine
+	name = "hypozine"
+	id = "hypozine"
+	result = "hypozine"
 	required_reagents = list("hyperzine" = 1, "peridaxon" = 1)
 	result_amount = 2
 
-/datum/chemical_reaction/pttoxin
-	name = "Toxin"
-	id = "pttoxin"
-	result = "pttoxin"
+/datum/chemical_reaction/percocet
+	name = "percocet"
+	id = "percocet"
+	result = "percocet"
 	required_reagents = list("paracetamol" = 1, "tramadol" = 1)
 	result_amount = 2
 
-/datum/chemical_reaction/sdtoxin
-	name = "Toxin"
-	id = "sdtoxin"
-	result = "sdtoxin"
+/datum/chemical_reaction/levoamphetamine
+	name = "Levoamphetamine"
+	id = "levoamphetamine"
+	result = "levoamphetamine"
 	required_reagents = list("synaptizine" = 1, "anti_toxin" = 1)
 	result_amount = 2
 

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -115,6 +115,7 @@
 		if(!.) return
 		M.reagent_pain_modifier += -60 // A bit stronger then paracetamol but weaker then tramadol.
 		holder.remove_reagent("tramadol", 8 * REM) // Think you're smart huh?
+		holder.remove_reagent("paracetamol", 8 * REM) // Nop
 
 
 	on_overdose(mob/living/M)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -114,6 +114,8 @@
 		. = ..()
 		if(!.) return
 		M.reagent_pain_modifier += -60 // A bit stronger then paracetamol but weaker then tramadol.
+		holder.remove_reagent("tramadol", 8 * REM) // Think you're smart huh?
+
 
 	on_overdose(mob/living/M)
 		M.hallucination = max(M.hallucination, 2) //Hallucinations and tox damage
@@ -195,7 +197,6 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	scannable = 1
-	overdose = REAGENTS_OVERDOSE
 	overdose_critical = REAGENTS_OVERDOSE_CRITICAL
 
 	on_mob_life(mob/living/M)
@@ -515,6 +516,7 @@
 			M.AdjustKnockedout(-1)
 			M.AdjustStunned(-1)
 			M.AdjustKnockeddown(-1)
+		holder.remove_reagent("synaptizine", 8 * REM) // hahah no
 	on_overdose(mob/living/M)
 		M.apply_damage(2, TOX)
 
@@ -741,7 +743,7 @@
 	on_mob_life(mob/living/M)
 		. = ..()
 		if(!.) return
-
+		holder.remove_reagent("hyperzine", 8 * REM) // stop
 		M.reagent_move_delay_modifier -= 0.25
 
 	on_overdose(mob/living/M)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -98,6 +98,31 @@
 
 	on_overdose_critical(mob/living/M)
 		M.apply_damage(4, TOX) //Massive liver damage
+		
+/datum/reagent/percocet
+	name = "Percocet"
+	id = "percocet"
+	description = "Percocet is a blend of a NASID and a opioid that delivers weak, but safe pain relief."
+	reagent_state = LIQUID
+	color = "#C855DC"
+	scannable = 1
+	custom_metabolism = 0.1 // Decays quickly.
+	overdose = REAGENTS_OVERDOSE*2
+	overdose_critical = REAGENTS_OVERDOSE_CRITICAL*2
+
+	on_mob_life(mob/living/M)
+		. = ..()
+		if(!.) return
+		M.reagent_pain_modifier += -60 // A bit stronger then paracetamol but weaker then tramadol.
+
+	on_overdose(mob/living/M)
+		M.hallucination = max(M.hallucination, 2) //Hallucinations and tox damage
+		if(prob(25)) // Safer.
+			M.apply_damage(1, TOX)
+
+	on_overdose_critical(mob/living/M)
+		M.apply_damage(2, TOX) // Good job.
+
 
 /datum/reagent/tramadol
 	name = "Tramadol"
@@ -470,6 +495,32 @@
 	on_overdose_critical(mob/living/M)
 		M.apply_damages(1, 1, 3)
 
+/datum/reagent/levoamphetamine
+	name = "levoamphetamine"
+	id = "levoamphetamine"
+	description = "Levoamphetamine is a weak, but safe, stimulant."
+	reagent_state = LIQUID
+	color = "#C8A5DC" // rgb: 200, 165, 220
+	custom_metabolism = 0.1
+	overdose = REAGENTS_OVERDOSE/3
+	overdose_critical = REAGENTS_OVERDOSE_CRITICAL/3
+	scannable = 1
+
+	on_mob_life(mob/living/M)
+		. = ..()
+		if(!.) return
+		M.reagent_shock_modifier += PAIN_REDUCTION_VERY_LIGHT
+		M.drowsyness = max(M.drowsyness-2, 0)
+		if(prob(25))
+			M.AdjustKnockedout(-1)
+			M.AdjustStunned(-1)
+			M.AdjustKnockeddown(-1)
+	on_overdose(mob/living/M)
+		M.apply_damage(2, TOX)
+
+	on_overdose_critical(mob/living/M)
+		M.apply_damage(4, TOX)
+
 /datum/reagent/neuraline //injected by neurostimulator implant
 	name = "Neuraline"
 	id = "neuraline"
@@ -676,6 +727,27 @@
 
 	on_overdose_critical(mob/living/M)
 		M.apply_damages(2, 3, 3)
+
+/datum/reagent/hypozine
+	name = "Hypozine"
+	id = "hypozine"
+	description = "Hypozine is a weak stimulant derived from Hyperzine."
+	reagent_state = LIQUID
+	color = "#C8A5DC" // rgb: 200, 165, 220
+	custom_metabolism = 0.2
+	overdose = REAGENTS_OVERDOSE/2
+	overdose_critical = REAGENTS_OVERDOSE_CRITICAL/2
+
+	on_mob_life(mob/living/M)
+		. = ..()
+		if(!.) return
+
+		M.reagent_move_delay_modifier -= 0.25
+
+	on_overdose(mob/living/M)
+		M.adjustToxLoss(1)
+	on_overdose_critical(mob/living/M)
+		M.adjustToxLoss(2)
 
 /datum/reagent/hyperzine
 	name = "Hyperzine"

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -102,7 +102,7 @@
 /datum/reagent/percocet
 	name = "Percocet"
 	id = "percocet"
-	description = "Percocet is a blend of a NASID and a opioid that delivers weak, but safe pain relief."
+	description = "Percocet is a blend of a NSAID and a opioid that delivers weak, but safe pain relief."
 	reagent_state = LIQUID
 	color = "#C855DC"
 	scannable = 1

--- a/code/modules/reagents/chemistry_reagents/toxin.dm
+++ b/code/modules/reagents/chemistry_reagents/toxin.dm
@@ -20,31 +20,6 @@
 			if(alien) holder.remove_reagent(id, custom_metabolism) //Kind of a catch-all for aliens without kidneys.
 			///I don't know what this is supposed to do, since aliens generally have kidneys, but I'm leaving it alone pending rework. /N
 
-/datum/reagent/toxin/hptoxin
-	name = "Toxin"
-	id = "hptoxin"
-	description = "A toxic chemical."
-	custom_metabolism = 1
-	toxpwr = 1
-
-/datum/reagent/toxin/pttoxin
-	name = "Toxin"
-	id = "pttoxin"
-	description = "A toxic chemical."
-	custom_metabolism = 1
-	toxpwr = 1
-
-/datum/reagent/toxin/sdtoxin
-	name = "Toxin"
-	id = "sdtoxin"
-	description = "A toxic chemical."
-	custom_metabolism = 1
-	toxpwr = 0
-	on_mob_life(mob/living/M,alien)
-		. = ..()
-		if(!.) return
-		M.adjustOxyLoss(1)
-
 
 /datum/reagent/toxin/amatoxin
 	name = "Amatoxin"


### PR DESCRIPTION
Right, so CM added some chems that are intended to prevent people from powergaming, for instance, blending hyperzine and peri creates toxin, same with paracetamol and tramadol, same with synaptizine and antitoxin, this PR removes those effects and makes the reactions simply make a weaker version of the chem, for instance, hyper+peri=hypozine, this gives you a very minor speedboost but without organ damage, para+tram=percocet, this reduces pain a bit more then para but way less then tramadol, and 
synap+antitox=Levoamphetamine, this gives minor stun reduction and drowsiness reduction but without the benefits of removing stuff like LSD.