### PR TITLE
Increases gestation speed when nested Tweak

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Embryo.dm
@@ -77,7 +77,7 @@
 		else if(stage == 4)
 			counter += 0.11
 	else if(istype(affected_mob.buckled, /obj/structure/bed/nest)) //Hosts who are nested in resin nests provide an ideal setting, larva grows faster
-		counter += 1.5 //Currently twice as much, can be changed
+		counter += 2.5 //Currently twice as much and a bit, can be changed
 	else
 		if(stage <= 4)
 			counter++


### PR DESCRIPTION
Bumps up the gestation speed when nested.
Current time for bursting when nested is around 17 minutes, this drops that to 10 minutes.

It currently feels too slow to get new xenos as the aliens, this should hopefully rectify that.