### PR TITLE
Fix Bayonets + Faster Attachment

### DIFF
--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -63,6 +63,8 @@ Defined in conflicts.dm of the #defines folder.
 	var/aim_speed_mod	= 0 //Changes the aiming speed slowdown of the wearer by this value.
 	var/wield_delay_mod	= 0 //How long ADS takes (time before firing)
 	var/movement_acc_penalty_mod = 0 //Modifies accuracy/scatter penalty when firing onehanded while moving.
+	var/attach_delay = 30 //How long in deciseconds it takes to attach a weapon with level 1 firearms training. Default is 30 seconds.
+	var/detach_delay = 30 //How long in deciseconds it takes to detach a weapon with level 1 firearms training. Default is 30 seconds.
 
 	var/activation_sound = 'sound/machines/click.ogg'
 
@@ -261,6 +263,8 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	attach_icon = "bayonet_a"
 	force = 20
 	throwforce = 10
+	attach_delay = 10 //Bayonets attach/detach quickly.
+	detach_delay = 10
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	melee_mod = 20 //35 for a rifle, comparable to 37 before. 40 with the stock, comparable to 42.
 	slot = "muzzle"

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -359,7 +359,7 @@ should be alright.
 	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		attach_delay *= 2
 		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach [attachment] to [src].</span>",
-		"<span class='notice'>You begin funmbling about, trying to attach [attachment] to [src].</span>", null, 4)
+		"<span class='notice'>You begin fumbling about, trying to attach [attachment] to [src].</span>", null, 4)
 	//user.visible_message("","<span class='notice'>Attach Delay = [attach_delay]. Attachment = [attachment]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
 	if(do_after(user,attach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		if(attachment && attachment.loc)
@@ -522,7 +522,7 @@ should be alright.
 	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		detach_delay *= 2
 		usr.visible_message("<span class='notice'>[usr] begins fumbling about, trying to strip [A] from [src].</span>",
-		"<span class='notice'>You begin funmbling about, trying to strip [A] from [src].</span>", null, 4)
+		"<span class='notice'>You begin fumbling about, trying to strip [A] from [src].</span>", null, 4)
 	//usr.visible_message("","<span class='notice'>Detach Delay = [detach_delay]. Attachment = [A]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
 	if(!do_after(usr,detach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		return

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -342,11 +342,17 @@ should be alright.
 		to_chat(user, "<span class='warning'>The attachment on [src]'s [attachment.slot] cannot be removed!</span>")
 		return
 
-	user.visible_message("<span class='notice'>[user] begins attaching [attachment] to [src].</span>",
-	"<span class='notice'>You begin attaching [attachment] to [src].</span>", null, 4)
+
 	var/attach_delay = 30
-	if(attachment == "bayonet" && !src.muzzle) //Attach the bayonet fast if there is no attachment to remove on the barrel
+	if(attachment == "bayonet" && (!src.muzzle || src.muzzle == "bayonet")) //Attach  bayonet fast if no attachment to remove on the barrel, or you're replacing a bayo with another bayo
 		attach_delay = 10
+	if(user.mind && user.mind.cm_skills && user.mind.cm_skills.firearms == 0) //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
+		attach_delay *= 2
+		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach the [attachment] to [src].</span>",
+		"<span class='notice'>You begin funmbling about, trying to attach the [attachment] to [src].</span>", null, 4)
+	else //attaching as usual.
+		user.visible_message("<span class='notice'>[user] begins attaching the [attachment] to [src].</span>",
+		"<span class='notice'>You begin attaching the [attachment] to [src].</span>", null, 4)
 	if(do_after(user,attach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		if(attachment && attachment.loc)
 			user.visible_message("<span class='notice'>[user] attaches [attachment] to [src].</span>",
@@ -496,14 +502,16 @@ should be alright.
 	if(!(A.flags_attach_features & ATTACH_REMOVABLE))
 		return
 
-	usr.visible_message("<span class='notice'>[usr] begins stripping [A] from [src].</span>",
-	"<span class='notice'>You begin stripping [A] from [src].</span>", null, 4)
-	
 	var/detach_delay = 30
 	if(A == "bayonet") //Detach the bayonet fast
 		detach_delay = 10
-	if(!do_after(usr,detach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
-		return
+	if(usr.mind && usr.mind.cm_skills && usr.mind.cm_skills.firearms == 0) //If the user has no training, detaching takes twice as long and they fumble about, looking like a retard.
+		detach_delay *= 2
+		usr.visible_message("<span class='notice'>[usr] begins fumbling about, trying to strip the [A] from [src].</span>",
+		"<span class='notice'>You begin fumbling about, trying to strip the [A] from [src].</span>", null, 4)
+	else //attaching as usual.
+		usr.visible_message("<span class='notice'>[usr] begins stripping the [A] from [src].</span>",
+		"<span class='notice'>You begin stripping the [A] from [src].</span>", null, 4)
 
 	if(A != rail && A != muzzle && A != under && A != stock)
 		return

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -498,8 +498,11 @@ should be alright.
 
 	usr.visible_message("<span class='notice'>[usr] begins stripping [A] from [src].</span>",
 	"<span class='notice'>You begin stripping [A] from [src].</span>", null, 4)
-
-	if(!do_after(usr,35, TRUE, 5, BUSY_ICON_FRIENDLY))
+	
+	var/detach_delay = 30
+	if(A == "bayonet") //Detach the bayonet fast
+		detach_delay = 10
+	if(!do_after(usr,detach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		return
 
 	if(A != rail && A != muzzle && A != under && A != stock)

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -344,7 +344,10 @@ should be alright.
 
 	user.visible_message("<span class='notice'>[user] begins attaching [attachment] to [src].</span>",
 	"<span class='notice'>You begin attaching [attachment] to [src].</span>", null, 4)
-	if(do_after(user,60, TRUE, 5, BUSY_ICON_FRIENDLY))
+	var/attach_delay = 30
+	if(attachment == "bayonet" && !src.muzzle) //Attach the bayonet fast if there is no attachment to remove on the barrel
+		attach_delay = 10
+	if(do_after(user,attach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		if(attachment && attachment.loc)
 			user.visible_message("<span class='notice'>[user] attaches [attachment] to [src].</span>",
 			"<span class='notice'>You attach [attachment] to [src].</span>", null, 4)

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -344,15 +344,23 @@ should be alright.
 
 
 	var/attach_delay = 30
-	if(attachment == "bayonet" && (!src.muzzle || src.muzzle == "bayonet")) //Attach  bayonet fast if no attachment to remove on the barrel, or you're replacing a bayo with another bayo
+	var/firearm_skill = user.mind.cm_skills.firearms
+	if(attachment.name == "bayonet" && (!src.muzzle || src.muzzle.name == "bayonet")) //Attach  bayonet fast if no attachment to remove on the barrel, or you're replacing a bayo with another bayo
 		attach_delay = 10
-	if(user.mind && user.mind.cm_skills && user.mind.cm_skills.firearms == 0) //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
+	if (user.mind && user.mind.cm_skills && firearm_skill)
+		if(attachment.name == "bayonet")
+			user.visible_message("<span class='notice'>[user] fixes [attachment]!.</span>",
+			"<span class='notice'>You fix [attachment]!</span>", null, 4)
+		else
+			user.visible_message("<span class='notice'>[user] begins attaching [attachment] to [src].</span>",
+			"<span class='notice'>You begin attaching [attachment] to [src].</span>", null, 4)
+		if(firearm_skill >= 2) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
+			attach_delay *= 0.5		
+	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		attach_delay *= 2
-		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach the [attachment] to [src].</span>",
-		"<span class='notice'>You begin funmbling about, trying to attach the [attachment] to [src].</span>", null, 4)
-	else //attaching as usual.
-		user.visible_message("<span class='notice'>[user] begins attaching the [attachment] to [src].</span>",
-		"<span class='notice'>You begin attaching the [attachment] to [src].</span>", null, 4)
+		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach [attachment] to [src].</span>",
+		"<span class='notice'>You begin funmbling about, trying to attach [attachment] to [src].</span>", null, 4)
+	//user.visible_message("","<span class='notice'>Attach Delay = [attach_delay]. Attachment = [attachment]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
 	if(do_after(user,attach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		if(attachment && attachment.loc)
 			user.visible_message("<span class='notice'>[user] attaches [attachment] to [src].</span>",
@@ -503,15 +511,21 @@ should be alright.
 		return
 
 	var/detach_delay = 30
-	if(A == "bayonet") //Detach the bayonet fast
+	var/firearm_skill = usr.mind.cm_skills.firearms
+	if(A.name == "bayonet") //Detach the bayonet fast
 		detach_delay = 10
-	if(usr.mind && usr.mind.cm_skills && usr.mind.cm_skills.firearms == 0) //If the user has no training, detaching takes twice as long and they fumble about, looking like a retard.
+	if (usr.mind && usr.mind.cm_skills && firearm_skill)
+		usr.visible_message("<span class='notice'>[usr] begins stripping [A] from [src].</span>",
+		"<span class='notice'>You begin stripping [A] from [src].</span>", null, 4)
+		if(firearm_skill >= 2) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
+			detach_delay *= 0.5		
+	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		detach_delay *= 2
-		usr.visible_message("<span class='notice'>[usr] begins fumbling about, trying to strip the [A] from [src].</span>",
-		"<span class='notice'>You begin fumbling about, trying to strip the [A] from [src].</span>", null, 4)
-	else //attaching as usual.
-		usr.visible_message("<span class='notice'>[usr] begins stripping the [A] from [src].</span>",
-		"<span class='notice'>You begin stripping the [A] from [src].</span>", null, 4)
+		usr.visible_message("<span class='notice'>[usr] begins fumbling about, trying to strip [A] from [src].</span>",
+		"<span class='notice'>You begin funmbling about, trying to strip [A] from [src].</span>", null, 4)
+	//usr.visible_message("","<span class='notice'>Detach Delay = [detach_delay]. Attachment = [A]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
+	if(!do_after(usr,detach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
+		return
 
 	if(A != rail && A != muzzle && A != under && A != stock)
 		return

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -343,16 +343,16 @@ should be alright.
 		return
 
 	var/final_delay = attachment.attach_delay
-	if (usr.mind.cm_skills.firearms)
+	if (user.mind.cm_skills.firearms)
 		user.visible_message("<span class='notice'>[user] begins attaching [attachment] to [src].</span>",
 		"<span class='notice'>You begin attaching [attachment] to [src].</span>", null, 4)
-		if(usr.mind.cm_skills.firearms >= SKILL_FIREARMS_DEFAULT) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
+		if(user.mind.cm_skills.firearms >= SKILL_FIREARMS_DEFAULT) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
 			final_delay *= 0.5
 	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
 		final_delay *= 2
 		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach [attachment] to [src].</span>",
 		"<span class='notice'>You begin fumbling about, trying to attach [attachment] to [src].</span>", null, 4)
-	//user.visible_message("","<span class='notice'>Attach Delay = [final_delay]. Attachment = [attachment]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
+	//user.visible_message("","<span class='notice'>Attach Delay = [final_delay]. Attachment = [attachment]. Firearm Skill = [user.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
 	if(do_after(user,final_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		if(attachment && attachment.loc)
 			user.visible_message("<span class='notice'>[user] attaches [attachment] to [src].</span>",

--- a/code/modules/projectiles/updated_projectiles/gun_helpers.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_helpers.dm
@@ -342,26 +342,18 @@ should be alright.
 		to_chat(user, "<span class='warning'>The attachment on [src]'s [attachment.slot] cannot be removed!</span>")
 		return
 
-
-	var/attach_delay = 30
-	var/firearm_skill = user.mind.cm_skills.firearms
-	if(attachment.name == "bayonet" && (!src.muzzle || src.muzzle.name == "bayonet")) //Attach  bayonet fast if no attachment to remove on the barrel, or you're replacing a bayo with another bayo
-		attach_delay = 10
-	if (user.mind && user.mind.cm_skills && firearm_skill)
-		if(attachment.name == "bayonet")
-			user.visible_message("<span class='notice'>[user] fixes [attachment]!.</span>",
-			"<span class='notice'>You fix [attachment]!</span>", null, 4)
-		else
-			user.visible_message("<span class='notice'>[user] begins attaching [attachment] to [src].</span>",
-			"<span class='notice'>You begin attaching [attachment] to [src].</span>", null, 4)
-		if(firearm_skill >= 2) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
-			attach_delay *= 0.5		
+	var/final_delay = attachment.attach_delay
+	if (usr.mind.cm_skills.firearms)
+		user.visible_message("<span class='notice'>[user] begins attaching [attachment] to [src].</span>",
+		"<span class='notice'>You begin attaching [attachment] to [src].</span>", null, 4)
+		if(usr.mind.cm_skills.firearms >= SKILL_FIREARMS_DEFAULT) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
+			final_delay *= 0.5
 	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
-		attach_delay *= 2
+		final_delay *= 2
 		user.visible_message("<span class='notice'>[user] begins fumbling about, trying to attach [attachment] to [src].</span>",
 		"<span class='notice'>You begin fumbling about, trying to attach [attachment] to [src].</span>", null, 4)
-	//user.visible_message("","<span class='notice'>Attach Delay = [attach_delay]. Attachment = [attachment]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
-	if(do_after(user,attach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
+	//user.visible_message("","<span class='notice'>Attach Delay = [final_delay]. Attachment = [attachment]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
+	if(do_after(user,final_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		if(attachment && attachment.loc)
 			user.visible_message("<span class='notice'>[user] attaches [attachment] to [src].</span>",
 			"<span class='notice'>You attach [attachment] to [src].</span>", null, 4)
@@ -510,21 +502,18 @@ should be alright.
 	if(!(A.flags_attach_features & ATTACH_REMOVABLE))
 		return
 
-	var/detach_delay = 30
-	var/firearm_skill = usr.mind.cm_skills.firearms
-	if(A.name == "bayonet") //Detach the bayonet fast
-		detach_delay = 10
-	if (usr.mind && usr.mind.cm_skills && firearm_skill)
+	var/final_delay = A.detach_delay
+	if (usr.mind.cm_skills.firearms)
 		usr.visible_message("<span class='notice'>[usr] begins stripping [A] from [src].</span>",
 		"<span class='notice'>You begin stripping [A] from [src].</span>", null, 4)
-		if(firearm_skill >= 2) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
-			detach_delay *= 0.5		
+		if(usr.mind.cm_skills.firearms > SKILL_FIREARMS_DEFAULT) //See if the attacher is super skilled/panzerelite born to defeat never retreat etc
+			final_delay *= 0.5 //Half normal time
 	else //If the user has no training, attaching takes twice as long and they fumble about, looking like a retard.
-		detach_delay *= 2
+		final_delay *= 2
 		usr.visible_message("<span class='notice'>[usr] begins fumbling about, trying to strip [A] from [src].</span>",
 		"<span class='notice'>You begin fumbling about, trying to strip [A] from [src].</span>", null, 4)
 	//usr.visible_message("","<span class='notice'>Detach Delay = [detach_delay]. Attachment = [A]. Firearm Skill = [usr.mind.cm_skills.firearms].</span>", null, 4) //DEBUG
-	if(!do_after(usr,detach_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
+	if(!do_after(usr,final_delay, TRUE, 5, BUSY_ICON_FRIENDLY))
 		return
 
 	if(A != rail && A != muzzle && A != under && A != stock)


### PR DESCRIPTION
Bayonets now attach in 1 second if there is no attachment to remove on the muzzle slot. Fix Bayonets!

All other attachments attach 3 seconds faster (3 seconds, down from 6) because fuck waiting for so long for no reason.

EDIT: If you're untrained with firearms, removing/adding attachments takes twice as long and you look like a bumbling idiot.