### PR TITLE
Remove permasleep from tank treads.

### DIFF
--- a/code/modules/vehicles/cm_armored.dm
+++ b/code/modules/vehicles/cm_armored.dm
@@ -408,7 +408,7 @@ var/list/TANK_HARDPOINT_OFFSETS = list(
 	if(.)
 		for(var/mob/living/M in get_turf(A))
 			//I don't call Bump() otherwise that would encourage trampling for infinite unpunishable damage
-			M.sleeping = 1e7 //Maintain their lying-down-ness
+			M.sleeping = 5 //Maintain their lying-down-ness
 
 /obj/vehicle/multitile/hitbox/cm_armored/Uncrossed(var/atom/movable/A)
 	if(isliving(A))


### PR DESCRIPTION
This is a small patch. I really dislike the method to stun targets here and the whole concept of sleep-inducing tank treads. This will have to be reworked later, but for now removing the bug will have to suffice.