### PR TITLE
Now you can play Gloomy Sunday at round end.

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -14,10 +14,8 @@
 
 	var/permitted = 0
 	var/list/allowed = list("Syndicate","traitor","Wizard","Head Revolutionary","Cultist","Changeling")
-	for(var/T in allowed)
-		if(mind.special_role == T || ticker.current_state == GAME_STATE_FINISHED)
-			permitted = 1
-			break
+	if((mind.special_role in allowed) || ticker.current_state == GAME_STATE_FINISHED)
+		permitted = 1
 
 	if(!permitted)
 		message_admins("[ckey] has tried to suicide, but they were not permitted due to not being antagonist as human.", 1)

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -15,7 +15,7 @@
 	var/permitted = 0
 	var/list/allowed = list("Syndicate","traitor","Wizard","Head Revolutionary","Cultist","Changeling")
 	for(var/T in allowed)
-		if(mind.special_role == T)
+		if(mind.special_role == T || ticker.current_state == GAME_STATE_FINISHED)
 			permitted = 1
 			break
 


### PR DESCRIPTION
Exactly what the tin says, I see little to no reason to retain suicide restrictions to gun in mouth while throwing the EORG one out of the window on game over, or at least this is what I think. Thoughts are accepted but policy discussion should be avoided here. The maintainers have the final say.

TO DO: Citing this on either game completion and/or suicide verb input. Suggestions are accepted.
FUTURE TO DO: Unrestric the verb from humanity and make it available to xenos/simple animals/Robots.
FAR FUTURE MAYBE TO DO: Add/Port fancy self-termination methods.