### PR TITLE
New smoke grenades that actually makes the passerbys (almost) invisible to benos. As seen on TV.

### DIFF
--- a/code/game/objects/effects/effect_system/smoke.dm
+++ b/code/game/objects/effects/effect_system/smoke.dm
@@ -119,6 +119,88 @@
 				M.coughedtime = 0
 
 /////////////////////////////////////////////
+// Cloak Smoke (SEE_MOBS Hur Dur)
+////////////////////////////////////////////
+/obj/effect/particle_effect/smoke/tactical
+
+/obj/effect/particle_effect/smoke/tactical/New(loc, oldamount)
+	..()
+	for(var/mob/living/M in get_turf(src))
+		affect(M)
+
+
+/obj/effect/particle_effect/smoke/tactical/Move()
+	..()
+	for(var/mob/living/M in get_turf(src))
+		affect(M)
+
+/obj/effect/particle_effect/smoke/tactical/Dispose()
+	for(var/mob/living/M in get_turf(src))
+		uncloak_smoke_act(M)
+	. =..()
+
+/obj/effect/particle_effect/smoke/tactical/affect(var/mob/living/M)
+	if (istype(M) && time_to_live >= 1)
+		cloak_smoke_act(M)
+	else
+		return
+
+/obj/effect/particle_effect/smoke/tactical/Crossed(atom/movable/M)
+	..()
+	if(isliving(M))
+		affect(M)
+
+/obj/effect/particle_effect/smoke/tactical/Cross(var/mob/living/M)
+	affect(M)
+
+/obj/effect/particle_effect/smoke/tactical/Uncrossed(var/mob/living/M)
+	..()
+	uncloak_smoke_act(M)
+
+/obj/effect/particle_effect/smoke/tactical/proc/cloak_smoke_act(var/mob/living/M)
+
+	if(!istype(M) || M.smokecloaked)
+		return
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.gloves)
+			var/obj/item/clothing/gloves/yautja/Y = H.gloves
+			if(istype(Y) && Y.cloaked)
+				return
+
+		if(H.back)
+			var/obj/item/storage/backpack/marine/satchel/scout_cloak/S = H.back
+			if(istype(S) && S.camo_active)
+				return
+
+	M.alpha = 10
+
+	if(!isXeno(M)||!isanimal(M))
+		var/datum/mob_hud/security/advanced/SA = huds[MOB_HUD_SECURITY_ADVANCED]
+		SA.remove_from_hud(M)
+		var/datum/mob_hud/xeno_infection/XI = huds[MOB_HUD_XENO_INFECTION]
+		XI.remove_from_hud(M)
+
+	M.smokecloaked = TRUE
+
+
+/obj/effect/particle_effect/smoke/tactical/proc/uncloak_smoke_act(var/mob/living/M)
+
+	if(!istype(M) || !M.smokecloaked)
+		return
+
+	M.alpha = initial(M.alpha)
+
+	if(!isXeno(M)|| !isanimal(M))
+		var/datum/mob_hud/security/advanced/SA = huds[MOB_HUD_SECURITY_ADVANCED]
+		SA.add_to_hud(M)
+		var/datum/mob_hud/xeno_infection/XI = huds[MOB_HUD_XENO_INFECTION]
+		XI.add_to_hud(M)
+
+	M.smokecloaked = FALSE
+
+/////////////////////////////////////////////
 // Sleep smoke
 /////////////////////////////////////////////
 
@@ -353,6 +435,9 @@
 
 /datum/effect_system/smoke_spread/bad
 	smoke_type = /obj/effect/particle_effect/smoke/bad
+
+datum/effect_system/smoke_spread/tactical
+	smoke_type = /obj/effect/particle_effect/smoke/tactical
 
 /datum/effect_system/smoke_spread/sleepy
 	smoke_type = /obj/effect/particle_effect/smoke/sleepy

--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -167,6 +167,26 @@ proc/flame_radius(radius = 1, turf/turf) //~Art updated fire.
 		smoke.start()
 		cdel(src)
 
+/obj/item/explosive/grenade/cloakbomb
+	name = "\improper M40-2 SCDP smoke grenade"
+	desc = "A sophisticated version of the M40 HSDP with an improved smoke screen payload, currently being field-tested in the USCM. It's set to detonate in 2 seconds."
+	icon_state = "grenade_cloak" //placeholder
+	det_time = 20
+	item_state = "grenade_cloak" //same
+	underslug_launchable = TRUE
+	var/datum/effect_system/smoke_spread/tactical/smoke
+
+	New()
+		..()
+		smoke = new /datum/effect_system/smoke_spread/tactical
+		smoke.attach(src)
+
+	prime()
+		playsound(src.loc, 'sound/effects/smoke.ogg', 25, 1, 4)
+		smoke.set_up(3, 0, usr.loc, null, 7)
+		smoke.start()
+		cdel(src)
+
 /obj/item/explosive/grenade/phosphorus
 	name = "\improper M40 HPDP grenade"
 	desc = "The M40 HPDP is a small, but powerful phosphorus grenade. It is set to detonate in 2 seconds."

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -121,6 +121,15 @@
 			continue
 		if(M.buckled)
 			continue
+		var/mob/living/L = M
+		if(L.smokecloaked)
+			L.alpha = initial(L.alpha)
+			if(!isanimal(L))
+				var/datum/mob_hud/security/advanced/SA = huds[MOB_HUD_SECURITY_ADVANCED]
+				SA.add_to_hud(L)
+				var/datum/mob_hud/xeno_infection/XI = huds[MOB_HUD_XENO_INFECTION]
+				XI.add_to_hud(L)
+			L.smokecloaked = FALSE
 
 		M.forceMove(src)
 		stored_units += mob_size

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -63,3 +63,5 @@
 	var/reagent_move_delay_modifier = 0 //negative values increase movement speed
 	var/reagent_shock_modifier = 0 //negative values reduce shock/pain
 	var/reagent_pain_modifier = 0 //same as above, except can potentially mask damage
+
+	var/smokecloaked = FALSE //For Cloak Nade


### PR DESCRIPTION
On behalf of the masses' complaints against the outdated HSDP grenades, I spent this day coding and testing and coding a the new brand SCDP (Smoke Screen ""Dual Purpose"") grenade, which is guaranteed to shielding against thermal vision to all mobs minus ghosts. Code isn't of the prettiest should be devoid of (hopefully) bugs and runtimes and shouldn't give off permanent cloaking on mundane occasions. 
Currently only adminspawnable for the delicate alpha reason, if anyone wants to test it, try going out the norms, tele in and out, admindelete the smoke, and report any problem or review.
TODO: Sprite the new grenade.