### PR TITLE
Corrects a warning being displayed by a check to see if a button should be displayed

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -452,7 +452,8 @@
 			dat += "<a href='?src=\ref[src];evac_authority=init_evac'>Initiate Evacuation</a><br>"
 			dat += "<a href='?src=\ref[src];evac_authority=cancel_evac'>Cancel Evacuation</a><br>"
 			dat += "<a href='?src=\ref[src];evac_authority=toggle_evac'>Toggle Evacuation Permission (does not affect evac in progress)</a><br>"
-			if(check_rights(R_ADMIN)) dat += "<a href='?src=\ref[src];evac_authority=force_evac'>Force Evacuation Now</a><br>"
+			if(check_rights(R_ADMIN, FALSE))
+				dat += "<a href='?src=\ref[src];evac_authority=force_evac'>Force Evacuation Now</a><br>"
 
 		if(check_rights(R_ADMIN, FALSE))
 			dat += "<b>Self Destruct:</b> "


### PR DESCRIPTION
Did CM even test their code?  The answer may surprise you.

🆑
bugfix: A message erroneously given by a permission check for displaying a button in the player panel 99% of you will never see has been fixed.
/🆑

Fixes #297 and also that obnoxious code on the same line as a check.  I don't know any style in any language that says that's okay.