### PR TITLE
Req Supplypacks Overhaul (Operators Operating Operationally)

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1296,7 +1296,7 @@ AMMO
 	group = "Ammo"
 
 /datum/supply_packs/ammo_scout_impact
-	name = "M4RA scout impact magazines crate (x4)"
+	name = "M4RA scout impact magazines crate (x3)"
 	contains = list(
 					/obj/item/ammo_magazine/rifle/m4ra/impact,
 					/obj/item/ammo_magazine/rifle/m4ra/impact,
@@ -1308,7 +1308,7 @@ AMMO
 	group = "Ammo"
 
 /datum/supply_packs/ammo_scout_incendiary
-	name = "M4RA scout incendiary magazines crate (x4)"
+	name = "M4RA scout incendiary magazines crate (x3)"
 	contains = list(
 					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
 					/obj/item/ammo_magazine/rifle/m4ra/incendiary,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -44,8 +44,9 @@ OPERATIONS
 
 /datum/supply_packs/specialops
 	name = "special operations crate (operator kit x2)"
-	contains = list(/obj/item/attachable/suppressor,
-					/obj/item/attachable/suppressor,
+	contains = list(
+					/obj/item/weapon/gun/pistol/b92fs/M9,
+					/obj/item/weapon/gun/pistol/b92fs/M9,
 					/obj/item/clothing/under/syndicate/combat,
 					/obj/item/clothing/under/syndicate/combat,
 					/obj/item/clothing/mask/gas/swat,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -882,20 +882,18 @@ ATTACHMENTS
 	group = "Attachments"
 
 /datum/supply_packs/s_attachables
-	name = "stock attachments crate (x3 each)"
+	name = "stock attachments crate (x2 each)"
 	contains = list(
 					/obj/item/attachable/stock/revolver,
 					/obj/item/attachable/stock/revolver,
-					/obj/item/attachable/stock/revolver,
 					/obj/item/attachable/stock/rifle,
 					/obj/item/attachable/stock/rifle,
-					/obj/item/attachable/stock/rifle,
-					/obj/item/attachable/stock/shotgun,
 					/obj/item/attachable/stock/shotgun,
 					/obj/item/attachable/stock/shotgun,
 					/obj/item/attachable/stock/smg,
 					/obj/item/attachable/stock/smg,
-					/obj/item/attachable/stock/smg
+					/obj/item/attachable/stock/tactical,
+					/obj/item/attachable/stock/tactical
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
@@ -955,7 +953,7 @@ ATTACHMENTS
 	group = "Attachments"
 
 /datum/supply_packs/stock_smg
-	name = "combat shotgun stock attachment crate (x4)"
+	name = "combat shotgun stock attachment crate (x3)"
 	contains = list(
 			/obj/item/attachable/stock/tactical,
 			/obj/item/attachable/stock/tactical,
@@ -1648,7 +1646,7 @@ CLOTHING
 					/obj/item/clothing/under/marine/officer/exec,
 					/obj/item/clothing/under/marine/officer/ce
 					)
-	name = "officer outfit closet"
+	name = "officer outfit crate"
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
 	containername = "\improper officer dress crate"
@@ -1669,7 +1667,7 @@ CLOTHING
 					/obj/item/clothing/shoes/marine,
 					/obj/item/clothing/shoes/marine
 					)
-	name = "marine outfit closet"
+	name = "marine outfit crate"
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
 	containername = "\improper marine outfit crate"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -4,6 +4,7 @@
 //NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
 //NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 
+#define RO_PRICE_NEAR_FREE	10
 #define RO_PRICE_VERY_CHEAP	20
 #define RO_PRICE_CHEAP		30
 #define RO_PRICE_NORMAL		40
@@ -85,7 +86,7 @@ OPERATIONS
 					/obj/item/device/binoculars,
 					/obj/item/device/binoculars
 					)
-	cost = RO_PRICE_VERY_CHEAP
+	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate
 	containername = "\improper binoculars crate"
 	group = "Operations"
@@ -96,7 +97,7 @@ OPERATIONS
 					/obj/item/device/binoculars/tactical,
 					/obj/item/device/binoculars/tactical
 					)
-	cost = RO_PRICE_CHEAP
+	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
 	containername = "\improper tactical binoculars crate"
 	group = "Operations"
@@ -112,6 +113,42 @@ OPERATIONS
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper flare pack crate"
+	group = "Operations"
+
+/datum/supply_packs/alpha
+	name = "Alpha Supply Crate"
+	contains = list(
+					)
+	cost = RO_PRICE_NEAR_FREE
+	containertype = /obj/structure/closet/crate/alpha
+	containername = "\improper Alpha Supply Crate"
+	group = "Operations"
+
+/datum/supply_packs/bravo
+	name = "Bravo Supply Crate"
+	contains = list(
+					)
+	cost = RO_PRICE_NEAR_FREE
+	containertype = /obj/structure/closet/crate/bravo
+	containername = "\improper Bravo Supply Crate"
+	group = "Operations"
+
+/datum/supply_packs/charlie
+	name = "Charlie Supply Crate"
+	contains = list(
+					)
+	cost = RO_PRICE_NEAR_FREE
+	containertype = /obj/structure/closet/crate/charlie
+	containername = "\improper Charlie Supply Crate"
+	group = "Operations"
+
+/datum/supply_packs/delta
+	name = "Delta Supply Crate"
+	contains = list(
+					)
+	cost = RO_PRICE_NEAR_FREE
+	containertype = /obj/structure/closet/crate/delta
+	containername = "\improper Delta Supply Crate"
 	group = "Operations"
 
 /datum/supply_packs/contraband
@@ -227,10 +264,11 @@ WEAPONS
 /datum/supply_packs/gun/combatshotgun
 	contains = list(
 					/obj/item/weapon/gun/shotgun/combat,
-					/obj/item/ammo_magazine/shotgun/flechette,
+					/obj/item/ammo_magazine/shotgun/,
+					/obj/item/ammo_magazine/shotgun/buckshot,
 					/obj/item/ammo_magazine/shotgun/flechette
 					)
-	name = "MK221 tactical shotgun crate (x1, flechette box x2)"
+	name = "MK221 tactical shotgun crate"
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
 	containername = "\improper MK221 tactical shotgun crate"
@@ -1257,10 +1295,8 @@ AMMO
 	group = "Ammo"
 
 /datum/supply_packs/ammo_scout_impact
-	name = "M4RA scout impact magazines crate (x5)"
+	name = "M4RA scout impact magazines crate (x4)"
 	contains = list(
-					/obj/item/ammo_magazine/rifle/m4ra/impact,
-					/obj/item/ammo_magazine/rifle/m4ra/impact,
 					/obj/item/ammo_magazine/rifle/m4ra/impact,
 					/obj/item/ammo_magazine/rifle/m4ra/impact,
 					/obj/item/ammo_magazine/rifle/m4ra/impact
@@ -1271,10 +1307,8 @@ AMMO
 	group = "Ammo"
 
 /datum/supply_packs/ammo_scout_incendiary
-	name = "M4RA scout incendiary magazines crate (x5)"
+	name = "M4RA scout incendiary magazines crate (x4)"
 	contains = list(
-					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
-					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
 					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
 					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
 					/obj/item/ammo_magazine/rifle/m4ra/incendiary
@@ -1376,7 +1410,9 @@ AMMO
 
 /datum/supply_packs/ammo_box_rifle
 	name = "large M41A ammo box crate (x400 rounds)"
-	contains = list(/obj/item/big_ammo_box)
+	contains = list(
+					/obj/item/big_ammo_box
+					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper M41A ammo box crate"
@@ -1384,7 +1420,9 @@ AMMO
 
 /datum/supply_packs/ammo_box_rifle_ap
 	name = "large armor piercing M41A ammo box crate (x400 AP rounds)"
-	contains = list(/obj/item/big_ammo_box/ap)
+	contains = list(
+					/obj/item/big_ammo_box/ap
+					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper M41A ammo box crate"
@@ -1392,7 +1430,9 @@ AMMO
 
 /datum/supply_packs/ammo_box_smg
 	name = "large M39 ammo box crate (x400 rounds)"
-	contains = list(/obj/item/big_ammo_box/smg)
+	contains = list(
+					/obj/item/big_ammo_box/smg
+					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper M39 ammo crate"
@@ -1436,16 +1476,11 @@ AMMO
 	randomised_num_contained = 10
 	contains = list(
 					/obj/item/ammo_magazine/rifle,
-					/obj/item/ammo_magazine/rifle,
-					/obj/item/ammo_magazine/rifle,
 					/obj/item/ammo_magazine/rifle/extended,
 					/obj/item/ammo_magazine/rifle/ap,
 					/obj/item/ammo_magazine/rifle/incendiary,
 					/obj/item/ammo_magazine/rifle/m41aMK1,
-					/obj/item/ammo_magazine/rifle/m4ra,
 					/obj/item/ammo_magazine/rifle/lmg,
-					/obj/item/ammo_magazine/pistol,
-					/obj/item/ammo_magazine/pistol,
 					/obj/item/ammo_magazine/pistol,
 					/obj/item/ammo_magazine/pistol/extended,
 					/obj/item/ammo_magazine/pistol/ap,
@@ -1453,18 +1488,12 @@ AMMO
 					/obj/item/ammo_magazine/pistol/incendiary,
 					/obj/item/ammo_magazine/pistol/m1911,
 					/obj/item/ammo_magazine/smg/m39,
-					/obj/item/ammo_magazine/smg/m39,
-					/obj/item/ammo_magazine/smg/m39,
 					/obj/item/ammo_magazine/smg/m39/extended,
 					/obj/item/ammo_magazine/smg/m39/ap,
-					/obj/item/ammo_magazine/revolver,
-					/obj/item/ammo_magazine/revolver,
 					/obj/item/ammo_magazine/revolver,
 					/obj/item/ammo_magazine/revolver/marksman,
 					/obj/item/ammo_magazine/revolver/heavy,
 					/obj/item/ammo_magazine/shotgun,
-					/obj/item/ammo_magazine/shotgun,
-					/obj/item/ammo_magazine/shotgun/buckshot,
 					/obj/item/ammo_magazine/shotgun/buckshot,
 					/obj/item/ammo_magazine/shotgun/incendiary
 					)
@@ -1734,7 +1763,7 @@ CLOTHING
 	group = "Clothing"
 
 /datum/supply_packs/pouches_ammo
-	name = "ammo pouches crate (1x normal, large, pistol, pistol large)"
+	name = "ammo pouches crate (1x normal, large, pistol, large pistol)"
 	contains = list(
 					/obj/item/storage/pouch/magazine,
 					/obj/item/storage/pouch/magazine/large,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -79,7 +79,7 @@ OPERATIONS
 	group = "Operations"
 
 /datum/supply_packs/binoculars_regular
-	name = "binoculars crate"
+	name = "binoculars crate (x1)"
 	contains = list(
 					/obj/item/device/binoculars
 					)
@@ -89,7 +89,7 @@ OPERATIONS
 	group = "Operations"
 
 /datum/supply_packs/binoculars_tatical
-	name = "tactical binoculars crate (x2)"
+	name = "tactical binoculars crate (x1)"
 	contains = list(
 					/obj/item/device/binoculars/tactical
 					)

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -47,18 +47,18 @@ OPERATIONS
 	name = "special operations crate (operator kit x2)"
 	contains = list(/obj/item/attachable/suppressor,
 					/obj/item/attachable/suppressor,
-					/obj/item/attachable/reddot,
-					/obj/item/attachable/reddot,
-					/obj/item/explosive/grenade/smokebomb,
-					/obj/item/explosive/grenade/smokebomb,
-					/obj/item/clothing/mask/gas/swat,
-					/obj/item/clothing/mask/gas/swat,
-					/obj/item/clothing/tie/storage/webbing,
-					/obj/item/clothing/tie/storage/webbing
+					/obj/item/clothing/under/syndicate/combat,
+					/obj/item/clothing/under/syndicate/combat,
+					/obj/item/clothing/glasses/night,
+					/obj/item/clothing/glasses/night,
+					/obj/item/clothing/mask/gas/PMC,
+					/obj/item/clothing/mask/gas/PMC,
+					/obj/item/clothing/tie/storage/black_vest,
+					/obj/item/clothing/tie/storage/black_vest
 					)
-	cost = RO_PRICE_PRICY
+	cost = RO_PRICE_VERY_PRICY
 	containertype = /obj/structure/closet/crate
-	containername = "special ops crate"
+	containername = "spec ops crate"
 	group = "Operations"
 
 /datum/supply_packs/beacons_supply
@@ -69,7 +69,7 @@ OPERATIONS
 			)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate
-	containername = "supply beacons crate"
+	containername = "\improper supply beacons crate"
 	group = "Operations"
 
 /datum/supply_packs/beacons_orbital
@@ -80,7 +80,7 @@ OPERATIONS
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
-	containername = "orbital beacons crate"
+	containername = "\improper orbital beacons crate"
 	group = "Operations"
 
 /datum/supply_packs/flares
@@ -93,7 +93,7 @@ OPERATIONS
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "flare pack crate"
+	containername = "\improper flare pack crate"
 	group = "Operations"
 
 /datum/supply_packs/contraband
@@ -108,7 +108,7 @@ OPERATIONS
 	name = "contraband crate"
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/supply
-	containername = "unlabeled crate"
+	containername = "\improper unlabeled crate"
 	contraband = 1
 	group = "Operations"
 
@@ -122,24 +122,12 @@ WEAPONS
 	name = "M240 Flamethrower crate (M240 x3)"
 	contains = list(
 					/obj/item/weapon/gun/flamer,
+					/obj/item/weapon/gun/flamer,
 					/obj/item/weapon/gun/flamer
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "\improper M240 Incinerator crate"
-	group = "Weapons"
-
-/datum/supply_packs/pyro
-	name = "M240-T fuel crate (extended x2, type-B x1, type-X x1)"
-	contains = list(
-					/obj/item/ammo_magazine/flamer_tank/large,
-					/obj/item/ammo_magazine/flamer_tank/large,
-					/obj/item/ammo_magazine/flamer_tank/large/B,
-					/obj/item/ammo_magazine/flamer_tank/large/X
-					)
-	cost = RO_PRICE_PRICY
-	containertype = /obj/structure/closet/crate/weapon
-	containername = "\improper M240-T fuel crate"
+	containername = "\improper M240 Flamethrower crate"
 	group = "Weapons"
 
 /datum/supply_packs/weapons_sentry
@@ -147,7 +135,7 @@ WEAPONS
 	contains = list()
 	cost = RO_PRICE_VERY_PRICY
 	containertype = /obj/item/storage/box/sentry
-	containername = "sentry crate"
+	containername = "\improper sentry crate"
 	group = "Weapons"
 
 /datum/supply_packs/gun/pistols
@@ -161,8 +149,8 @@ WEAPONS
 					/obj/item/ammo_magazine/revolver,
 					/obj/item/ammo_magazine/revolver
 					)
-	name = "surplus idearms crate (M4A3 x2, M44 x2, ammo x2 each)"
-	cost = RO_PRICE_NORMAL
+	name = "surplus sidearms crate (M4A3 x2, M44 x2, ammo x2 each)"
+	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
 	containername = "\improper sidearms crate"
 	group = "Weapons"
@@ -177,7 +165,7 @@ WEAPONS
 					/obj/item/ammo_magazine/shotgun/buckshot
 					)
 	name = "surplus shotguns crate (M37A2 x2, M37A2 ammo x2 each)"
-	cost = RO_PRICE_NORMAL
+	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
 	containername = "\improper shotguns crate"
 	group = "Weapons"
@@ -189,8 +177,8 @@ WEAPONS
 					/obj/item/ammo_magazine/smg/m39,
 					/obj/item/ammo_magazine/smg/m39
 					)
-	name = "surplus SMGd crate (M39 x2, M39 ammo x2)"
-	cost = RO_PRICE_NORMAL
+	name = "surplus SMG crate (M39 x2, M39 ammo x2)"
+	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
 	containername = "\improper SMGs crate"
 	group = "Weapons"
@@ -203,20 +191,32 @@ WEAPONS
 					/obj/item/ammo_magazine/rifle
 					)
 	name = "surplus rifles crate (M41A x2, M41A ammo x2)"
-	cost = RO_PRICE_NORMAL
+	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
 	containername = "\improper rifles crate"
 	group = "Weapons"
 
-/datum/supply_packs/gun/heavyweapons
+/datum/supply_packs/gun/heavyrifle
 	contains = list(
 					/obj/item/weapon/gun/rifle/lmg,
-					/obj/item/ammo_magazine/rifle/lmg,
+					/obj/item/ammo_magazine/rifle/lmg
 					)
 	name = "M41AE2 HPR crate (HPR x1, HPR ammo box x1)"
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
 	containername = "\improper M41AE2 HPR crate"
+	group = "Weapons"
+
+/datum/supply_packs/gun/combatshotgun
+	contains = list(
+					/obj/item/weapon/gun/shotgun/combat,
+					/obj/item/ammo_magazine/shotgun/flechette,
+					/obj/item/ammo_magazine/shotgun/flechette
+					)
+	name = "MK221 tactical shotgun crate (x1, flechette box x2)"
+	cost = RO_PRICE_PRICY
+	containertype = /obj/structure/closet/crate
+	containername = "\improper MK221 tactical shotgun crate"
 	group = "Weapons"
 
 /datum/supply_packs/gun/merc
@@ -236,7 +236,7 @@ WEAPONS
 	name = "M39 holster crate (x2)"
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "holster crate"
+	containername = "\improper holster crate"
 	group = "Weapons"
 
 /datum/supply_packs/gun_holster/m44
@@ -336,6 +336,19 @@ WEAPONS
 	containername = "\improper explosive HEDP grenade crate (WARNING)"
 	group = "Weapons"
 
+/datum/supply_packs/plastique
+	name = "plastic explosives crate (x5)"
+	contains = list(
+					/obj/item/explosive/plastique,
+					/obj/item/explosive/plastique,
+					/obj/item/explosive/plastique,
+					/obj/item/explosive/plastique,
+					/obj/item/explosive/plastique
+					)
+	cost = RO_PRICE_PRICY
+	containertype = /obj/structure/closet/crate/explosives
+	containername = "\improper plastic explosives crate (WARNING)"
+	group = "Weapons"
 
 /datum/supply_packs/mortar
 	name = "M402 mortar crate (x1)"
@@ -356,7 +369,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/primary/cannon)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/ltaaap_minigun
@@ -364,7 +377,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/primary/minigun)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/flamer_module
@@ -372,7 +385,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/secondary/flamer)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/towlauncher
@@ -380,7 +393,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/secondary/towlauncher)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/m56_cupola
@@ -388,7 +401,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/secondary/m56cupola)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/tank_glauncher
@@ -396,7 +409,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/secondary/grenade_launcher)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/tank_slauncher
@@ -404,7 +417,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/support/smoke_launcher)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/weapons_sensor
@@ -412,7 +425,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/support/weapons_sensor)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/artillery_module
@@ -420,7 +433,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/support/artillery_module)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/overdrive_enhancer
@@ -428,7 +441,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/support/overdrive_enhancer)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/ballistic_armor
@@ -436,7 +449,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/armor/ballistic)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/caustic_armor
@@ -444,7 +457,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/armor/caustic)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/concussive_armor
@@ -452,7 +465,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/armor/concussive)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/paladin_armor
@@ -460,7 +473,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/armor/paladin)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/snowplow_armor
@@ -468,7 +481,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/armor/snowplow)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/tank_treads
@@ -476,7 +489,7 @@ HARDPOINT MODULES (and their ammo)
 	contains = list(/obj/item/hardpoint/treads/standard)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/weapon
-	containername = "hardpoint module assembly crate"
+	containername = "\improper hardpoint module assembly crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/ltb_cannon_ammo
@@ -494,7 +507,7 @@ HARDPOINT MODULES (and their ammo)
 					/obj/item/ammo_magazine/tank/ltb_cannon)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
+	containername = "\improper tank ammo crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/ltaaap_minigun_ammo
@@ -505,7 +518,7 @@ HARDPOINT MODULES (and their ammo)
 					/obj/item/ammo_magazine/tank/ltaaap_minigun)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
+	containername = "\improper tank ammo crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/tank_glauncher_ammo
@@ -523,7 +536,7 @@ HARDPOINT MODULES (and their ammo)
 					/obj/item/ammo_magazine/tank/tank_glauncher)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
+	containername = "\improper tank ammo crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/tank_slauncher_ammo
@@ -541,7 +554,7 @@ HARDPOINT MODULES (and their ammo)
 					/obj/item/ammo_magazine/tank/tank_slauncher)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
+	containername = "\improper tank ammo crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/tank_towlauncher_ammo
@@ -553,7 +566,7 @@ HARDPOINT MODULES (and their ammo)
 					/obj/item/ammo_magazine/tank/towlauncher)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
+	containername = "\improper tank ammo crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/tank_cupola_ammo
@@ -563,7 +576,7 @@ HARDPOINT MODULES (and their ammo)
 					/obj/item/ammo_magazine/tank/m56_cupola)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
+	containername = "\improper tank ammo crate"
 	group = "Hardpoint Modules"
 
 /datum/supply_packs/tank_flamer_ammo
@@ -576,7 +589,7 @@ HARDPOINT MODULES (and their ammo)
 					/obj/item/ammo_magazine/tank/flamer)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
+	containername = "\improper tank ammo crate"
 	group = "Hardpoint Modules"
 
 
@@ -601,7 +614,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
-	containername = "attachables crate"
+	containername = "\improper attachables crate"
 	group = "Attachments"
 
 /datum/supply_packs/rail_reddot
@@ -618,7 +631,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "red-dot sight attachment crate"
+	containername = "\improper red-dot sight attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/rail_scope
@@ -629,7 +642,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "scope attachment crate"
+	containername = "\improper scope attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/rail_miniscope
@@ -640,7 +653,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "mini scope attachment crate"
+	containername = "\improper mini scope attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/rail_magneticharness
@@ -655,7 +668,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "magnetic harness attachment crate"
+	containername = "\improper magnetic harness attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/rail_quickfire
@@ -666,7 +679,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "quickfire attachment crate"
+	containername = "\improper quickfire attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/m_attachables
@@ -685,7 +698,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
-	containername = "attachables crate"
+	containername = "\improper attachables crate"
 	group = "Attachments"
 
 /datum/supply_packs/muzzle_suppressor
@@ -702,7 +715,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "suppressor attachment crate"
+	containername = "\improper suppressor attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/muzzle_bayonet
@@ -719,7 +732,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "bayonet attachment crate"
+	containername = "\improper bayonet attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/muzzle_extended
@@ -734,7 +747,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "extended barrel attachment crate"
+	containername = "\improper extended barrel attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/muzzle_heavy
@@ -745,7 +758,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "heavy barrel attachment crate"
+	containername = "\improper heavy barrel attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/muzzle_compensator
@@ -760,7 +773,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "compensator attachment crate"
+	containername = "\improper compensator attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/underbarrel_attachables
@@ -785,7 +798,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
-	containername = "attachables crate"
+	containername = "\improper attachables crate"
 	group = "Attachments"
 
 /datum/supply_packs/underbarrel_foregrip
@@ -802,7 +815,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "foregrip attachment crate"
+	containername = "\improper foregrip attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/underbarrel_gyro
@@ -813,7 +826,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "gyro attachment crate"
+	containername = "\improper gyro attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/underbarrel_bipod
@@ -828,7 +841,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "bipod attachment crate"
+	containername = "\improper bipod attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/underbarrel_shotgun
@@ -841,7 +854,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "shotgun attachment crate"
+	containername = "\improper shotgun attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/underbarrel_flamer
@@ -854,7 +867,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "flamer attachment crate"
+	containername = "\improper flamer attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/underbarrel_burstfire_assembly
@@ -865,7 +878,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "burstfire assembly attachment crate"
+	containername = "\improper burstfire assembly attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/s_attachables
@@ -882,11 +895,11 @@ ATTACHMENTS
 					/obj/item/attachable/stock/shotgun,
 					/obj/item/attachable/stock/smg,
 					/obj/item/attachable/stock/smg,
-					/obj/item/attachable/stock/smg,
+					/obj/item/attachable/stock/smg
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
-	containername = "stocks crate"
+	containername = "\improper stocks crate"
 	group = "Attachments"
 
 /datum/supply_packs/stock_revolver
@@ -899,7 +912,7 @@ ATTACHMENTS
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "stock revolver attachment crate"
+	containername = "\improper stock revolver attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/stock_rifle
@@ -912,7 +925,7 @@ ATTACHMENTS
 			)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "stock rifle attachment crate"
+	containername = "\improper rifle stock attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/stock_shotgun
@@ -925,7 +938,7 @@ ATTACHMENTS
 			)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "stock shotgun attachment crate"
+	containername = "\improper shotgun stock attachment crate"
 	group = "Attachments"
 
 /datum/supply_packs/stock_smg
@@ -938,9 +951,20 @@ ATTACHMENTS
 			)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "stock smg attachment crate"
+	containername = "\improper smg stock attachment crate"
 	group = "Attachments"
 
+/datum/supply_packs/stock_smg
+	name = "combat shotgun stock attachment crate (x4)"
+	contains = list(
+			/obj/item/attachable/stock/tactical,
+			/obj/item/attachable/stock/tactical,
+			/obj/item/attachable/stock/tactical
+			)
+	cost = RO_PRICE_CHEAP
+	containertype = /obj/structure/closet/crate
+	containername = "\improper combat shotgun attachment crate"
+	group = "Attachments"
 
 /*******************************************************************************
 AMMO
@@ -948,7 +972,7 @@ AMMO
 
 
 /datum/supply_packs/ammo_regular
-	name = "regular magazines crate (M41A x5, M4A3 x2, M44 x2, M39 x2, M37A2 x1 each)"
+	name = "regular magazines crate (M41A x5, M4A3 x2, M44 x2, M39 x2, M37A2 x1)"
 	contains = list(
 					/obj/item/ammo_magazine/rifle,
 					/obj/item/ammo_magazine/rifle,
@@ -966,7 +990,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "ammo crate"
+	containername = "\improper regular ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_regular_m41a
@@ -983,7 +1007,7 @@ AMMO
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M41A regular ammo crate"
+	containername = "\improper M41A regular ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_regular_m4a3
@@ -1002,7 +1026,7 @@ AMMO
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M4A3 regular ammo crate"
+	containername = "\improper M4A3 regular ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_regular_m44
@@ -1021,7 +1045,7 @@ AMMO
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M44 regular ammo crate"
+	containername = "\improper M44 regular ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_regular_m39
@@ -1040,11 +1064,11 @@ AMMO
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M39 regular ammo crate"
+	containername = "\improper M39 regular ammo crate"
 	group = "Ammo"
 
-/datum/supply_packs/ammo_regular_m37a2
-	name = "regular M37A2 shells crate (x5 slugs, x5 buckshot)"
+/datum/supply_packs/ammo_regular_shotgun
+	name = "regular shotgun shells crate (x5 slugs, x5 buckshot)"
 	contains = list(
 					/obj/item/ammo_magazine/shotgun,
 					/obj/item/ammo_magazine/shotgun,
@@ -1059,8 +1083,10 @@ AMMO
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M37A2 ammo crate"
+	containername = "\improper M37A2 ammo crate"
 	group = "Ammo"
+
+
 
 /datum/supply_packs/ammo_extended
 	name = "extended magazines crate (M41A x2, M4A3 x2, M39 x2)"
@@ -1074,7 +1100,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "extended ammo crate"
+	containername = "\improper extended ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_extended_m41a
@@ -1089,7 +1115,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M41A extended ammo crate"
+	containername = "\improper M41A extended ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_extended_m4a3
@@ -1106,7 +1132,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M4A3 extended ammo crate"
+	containername = "\improper M4A3 extended ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_extended_m39
@@ -1121,7 +1147,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M39 extended ammo crate"
+	containername = "\improper M39 extended ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_ap
@@ -1136,7 +1162,7 @@ AMMO
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "armor piercing ammo crate"
+	containername = "\improper armor piercing ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_ap_m41a
@@ -1151,7 +1177,7 @@ AMMO
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M41A armor piercing ammo crate"
+	containername = "\improper M41A armor piercing ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_ap_m4a3
@@ -1168,7 +1194,7 @@ AMMO
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M4A3 armor piercing ammo crate"
+	containername = "\improper M4A3 armor piercing ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_ap_m39
@@ -1183,21 +1209,64 @@ AMMO
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "M39 armor piercing ammo crate"
+	containername = "\improper M39 armor piercing ammo crate"
 	group = "Ammo"
 
+/datum/supply_packs/ammo_flechette_shotgun
+	name = "flechette shotgun shells crate (x5)"
+	contains = list(
+					/obj/item/ammo_magazine/shotgun/flechette,
+					/obj/item/ammo_magazine/shotgun/flechette,
+					/obj/item/ammo_magazine/shotgun/flechette,
+					/obj/item/ammo_magazine/shotgun/flechette,
+					/obj/item/ammo_magazine/shotgun/flechette
+					)
+	cost = RO_PRICE_VERY_CHEAP
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "\improper M37A2 ammo crate"
+	group = "Ammo"
+
+
 /datum/supply_packs/ammo_scout_regular
-	name = "M4RA scout magazines crate (regular x3, incendiary x1, impact x1)"
+	name = "M4RA scout magazines crate (x5)"
 	contains = list(
 					/obj/item/ammo_magazine/rifle/m4ra,
 					/obj/item/ammo_magazine/rifle/m4ra,
 					/obj/item/ammo_magazine/rifle/m4ra,
-					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
-					/obj/item/ammo_magazine/rifle/m4ra/impact,
+					/obj/item/ammo_magazine/rifle/m4ra,
+					/obj/item/ammo_magazine/rifle/m4ra
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "scout ammo crate"
+	containername = "\improper regular scout ammo crate"
+	group = "Ammo"
+
+/datum/supply_packs/ammo_scout_impact
+	name = "M4RA scout impact magazines crate (x5)"
+	contains = list(
+					/obj/item/ammo_magazine/rifle/m4ra/impact,
+					/obj/item/ammo_magazine/rifle/m4ra/impact,
+					/obj/item/ammo_magazine/rifle/m4ra/impact,
+					/obj/item/ammo_magazine/rifle/m4ra/impact,
+					/obj/item/ammo_magazine/rifle/m4ra/impact
+					)
+	cost = RO_PRICE_CHEAP
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "\improper impact scout ammo crate"
+	group = "Ammo"
+
+/datum/supply_packs/ammo_scout_incendiary
+	name = "M4RA scout incendiary magazines crate (x5)"
+	contains = list(
+					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
+					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
+					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
+					/obj/item/ammo_magazine/rifle/m4ra/incendiary,
+					/obj/item/ammo_magazine/rifle/m4ra/incendiary
+					)
+	cost = RO_PRICE_NORMAL
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "\improper incendiary scout ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_sniper_regular
@@ -1212,7 +1281,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "regular sniper ammo crate"
+	containername = "\improper regular sniper ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_sniper_flak
@@ -1227,7 +1296,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "flak sniper ammo crate"
+	containername = "\improper flak sniper ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_sniper_incendiary
@@ -1242,7 +1311,7 @@ AMMO
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "incendiary sniper ammo crate"
+	containername = "\improper incendiary sniper ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_rpg_regular
@@ -1257,7 +1326,7 @@ AMMO
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/explosives
-	containername = "regular M5 RPG ammo crate"
+	containername = "\improper regular M5 RPG ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_rpg_ap
@@ -1272,7 +1341,7 @@ AMMO
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/explosives
-	containername = "armor piercing M5 RPG ammo crate"
+	containername = "\improper armor piercing M5 RPG ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_rpg_wp
@@ -1287,7 +1356,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/explosives
-	containername = "white phosphorus M5 RPG ammo crate"
+	containername = "\improper white phosphorus M5 RPG ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_box_rifle
@@ -1295,7 +1364,7 @@ AMMO
 	contains = list(/obj/item/big_ammo_box)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "ammo crate"
+	containername = "\improper M41A ammo box crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_box_rifle_ap
@@ -1303,7 +1372,7 @@ AMMO
 	contains = list(/obj/item/big_ammo_box/ap)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "ammo crate"
+	containername = "\improper M41A ammo box crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_box_smg
@@ -1311,7 +1380,7 @@ AMMO
 	contains = list(/obj/item/big_ammo_box/smg)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "ammo crate"
+	containername = "\improper M39 ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_black_market
@@ -1343,7 +1412,7 @@ AMMO
 	cost = RO_PRICE_NORMAL
 	contraband = 1
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "black market ammo crate"
+	containername = "\improper black market ammo crate"
 	group = "Ammo"
 
 //This crate has a little bit of everything, mostly okay stuff, but it does have some really unique picks.
@@ -1386,7 +1455,7 @@ AMMO
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "surplus ammo crate"
+	containername = "\improper surplus ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_smartgun
@@ -1397,7 +1466,7 @@ AMMO
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "smartgun powerpack crate"
+	containername = "\improper smartgun powerpack crate"
 	group = "Ammo"
 
 /datum/supply_packs/ammo_sentry
@@ -1408,20 +1477,35 @@ AMMO
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "ammo crate"
+	containername = "\improper sentry ammo crate"
 	group = "Ammo"
 
 /datum/supply_packs/napalm
-	name = "UT-Napthal Fuel (x6)"
+	name = "M240 fuel crate (x6)"
 	contains = list(
 					/obj/item/ammo_magazine/flamer_tank,
 					/obj/item/ammo_magazine/flamer_tank,
 					/obj/item/ammo_magazine/flamer_tank,
 					/obj/item/ammo_magazine/flamer_tank,
+					/obj/item/ammo_magazine/flamer_tank,
+					/obj/item/ammo_magazine/flamer_tank
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
-	containername = "napthal fuel crate"
+	containername = "\improper M240 fuel crate"
+	group = "Ammo"
+
+/datum/supply_packs/pyro
+	name = "M240-T fuel crate (extended x2, type-B x1, type-X x1)"
+	contains = list(
+					/obj/item/ammo_magazine/flamer_tank/large,
+					/obj/item/ammo_magazine/flamer_tank/large,
+					/obj/item/ammo_magazine/flamer_tank/large/B,
+					/obj/item/ammo_magazine/flamer_tank/large/X
+					)
+	cost = RO_PRICE_PRICY
+	containertype = /obj/structure/closet/crate/weapon
+	containername = "\improper M240-T fuel crate"
 	group = "Ammo"
 
 /datum/supply_packs/mortar_ammo_he
@@ -1536,7 +1620,7 @@ ARMOR
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "armor crate"
+	containername = "\improper armor crate"
 	group = "Armor"
 
 /datum/supply_packs/armor_leader
@@ -1547,7 +1631,7 @@ ARMOR
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "squad leader armor crate"
+	containername = "\improper squad leader armor crate"
 	group = "Armor"
 
 
@@ -1566,8 +1650,8 @@ CLOTHING
 					)
 	name = "officer outfit closet"
 	cost = RO_PRICE_CHEAP
-	containertype = /obj/structure/closet
-	containername = "officer dress closet"
+	containertype = /obj/structure/closet/crate
+	containername = "\improper officer dress crate"
 	group = "Clothing"
 
 /datum/supply_packs/marine_outfits
@@ -1587,8 +1671,8 @@ CLOTHING
 					)
 	name = "marine outfit closet"
 	cost = RO_PRICE_VERY_CHEAP
-	containertype = /obj/structure/closet
-	containername = "marine outfit closet"
+	containertype = /obj/structure/closet/crate
+	containername = "\improper marine outfit crate"
 	group = "Clothing"
 
 /datum/supply_packs/webbing
@@ -1606,7 +1690,7 @@ CLOTHING
 					)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate
-	containername = "extra storage crate"
+	containername = "\improper extra storage crate"
 	group = "Clothing"
 
 /datum/supply_packs/pouches_general
@@ -1619,7 +1703,7 @@ CLOTHING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "general pouches crate"
+	containername = "\improper general pouches crate"
 	group = "Clothing"
 
 /datum/supply_packs/pouches_weapons
@@ -1631,7 +1715,7 @@ CLOTHING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "weapons pouches crate"
+	containername = "\improper weapons pouches crate"
 	group = "Clothing"
 
 /datum/supply_packs/pouches_ammo
@@ -1644,7 +1728,7 @@ CLOTHING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "ammo pouches crate"
+	containername = "\improper ammo pouches crate"
 	group = "Clothing"
 
 /datum/supply_packs/pouches_medical
@@ -1658,7 +1742,7 @@ CLOTHING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "medical pouches crate"
+	containername = "\improper medical pouches crate"
 	group = "Clothing"
 
 /datum/supply_packs/pouches_survival
@@ -1670,7 +1754,7 @@ CLOTHING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "survival pouches crate"
+	containername = "\improper survival pouches crate"
 	group = "Clothing"
 
 /datum/supply_packs/pouches_construction
@@ -1683,7 +1767,7 @@ CLOTHING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
-	containername = "construction pouches crate"
+	containername = "\improper construction pouches crate"
 	group = "Clothing"
 
 
@@ -1717,7 +1801,7 @@ MEDICAL
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/medical
-	containername = "medical crate"
+	containername = "\improper medical crate"
 	group = "Medical"
 
 /datum/supply_packs/firstaid
@@ -1735,7 +1819,7 @@ MEDICAL
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/medical
-	containername = "medical crate"
+	containername = "\improper medical crate"
 	group = "Medical"
 
 /datum/supply_packs/bodybag
@@ -1748,7 +1832,7 @@ MEDICAL
 			)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/medical
-	containername = "body bag crate"
+	containername = "\improper body bag crate"
 	group = "Medical"
 
 /datum/supply_packs/cryobag
@@ -1760,7 +1844,7 @@ MEDICAL
 			)
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/medical
-	containername = "stasis bag crate"
+	containername = "\improper stasis bag crate"
 	group = "Medical"
 
 /datum/supply_packs/surgery
@@ -1771,7 +1855,7 @@ MEDICAL
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/secure/surgery
-	containername = "surgery crate"
+	containername = "\improper surgery crate"
 	access = ACCESS_MARINE_MEDBAY
 	group = "Medical"
 
@@ -1789,7 +1873,7 @@ MEDICAL
 					)
 	cost = RO_PRICE_CHEAP
 	containertype = /obj/structure/closet/crate/secure/surgery
-	containername = "surgery crate"
+	containername = "\improper surgery crate"
 	access = ACCESS_MARINE_MEDBAY
 	group = "Medical"
 
@@ -1803,7 +1887,7 @@ MEDICAL
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/medical
-	containername = "sterile equipment crate"
+	containername = "\improper sterile equipment crate"
 	group = "Medical"
 
 
@@ -1818,7 +1902,7 @@ ENGINEERING
 	amount = 50
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = "/obj/structure/closet/crate/supply"
-	containername = "empty sandbags crate"
+	containername = "\improper empty sandbags crate"
 	group = "Engineering"
 
 /datum/supply_packs/metal50
@@ -1827,7 +1911,7 @@ ENGINEERING
 	amount = 50
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/supply
-	containername = "metal sheets crate"
+	containername = "\improper metal sheets crate"
 	group = "Engineering"
 
 /datum/supply_packs/plas50
@@ -1836,7 +1920,7 @@ ENGINEERING
 	amount = 30
 	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/supply
-	containername = "plasteel sheets crate"
+	containername = "\improper plasteel sheets crate"
 	group = "Engineering"
 
 /datum/supply_packs/glass50
@@ -1845,7 +1929,7 @@ ENGINEERING
 	amount = 50
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/supply
-	containername = "glass sheets crate"
+	containername = "\improper glass sheets crate"
 	group = "Engineering"
 
 /datum/supply_packs/wood50
@@ -1854,7 +1938,7 @@ ENGINEERING
 	amount = 50
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/supply
-	containername = "wooden planks crate"
+	containername = "\improper wooden planks crate"
 	group = "Engineering"
 
 /datum/supply_packs/smescoil
@@ -1862,7 +1946,7 @@ ENGINEERING
 	contains = list(/obj/item/stock_parts/smes_coil)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/construction
-	containername = "superconducting magnetic coil crate"
+	containername = "\improper superconducting magnetic coil crate"
 	group = "Engineering"
 
 /datum/supply_packs/electrical
@@ -1879,7 +1963,7 @@ ENGINEERING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/construction
-	containername = "electrical maintenance crate"
+	containername = "\improper electrical maintenance crate"
 	group = "Engineering"
 
 /datum/supply_packs/mechanical
@@ -1897,7 +1981,7 @@ ENGINEERING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/construction
-	containername = "mechanical maintenance crate"
+	containername = "\improper mechanical maintenance crate"
 	group = "Engineering"
 
 /datum/supply_packs/fueltank
@@ -1905,7 +1989,7 @@ ENGINEERING
 	contains = list(/obj/structure/reagent_dispensers/fueltank)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/largecrate
-	containername = "fuel tank crate"
+	containername = "\improper fuel tank crate"
 	group = "Engineering"
 
 /datum/supply_packs/inflatable
@@ -1917,7 +2001,7 @@ ENGINEERING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/construction
-	containername = "inflatable barriers crate"
+	containername = "\improper inflatable barriers crate"
 	group = "Engineering"
 
 /datum/supply_packs/lightbulbs
@@ -1929,7 +2013,7 @@ ENGINEERING
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/supply
-	containername = "replacement lights crate"
+	containername = "\improper replacement lights crate"
 	group = "Engineering"
 
 /datum/supply_packs/pacman_parts
@@ -1983,7 +2067,7 @@ SCIENCE
 					)
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate/secure/phoron
-	containername = "phoron assembly crate"
+	containername = "\improper phoron assembly crate"
 	access = ACCESS_MARINE_ENGINEERING
 	group = "Science"
 
@@ -2019,7 +2103,7 @@ SUPPLIES
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/internals
-	containername = "internals crate"
+	containername = "\improper internals crate"
 	group = "Supplies"
 
 /datum/supply_packs/evacuation
@@ -2042,7 +2126,7 @@ SUPPLIES
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/internals
-	containername = "emergency crate"
+	containername = "\improper emergency crate"
 	group = "Supplies"
 
 /datum/supply_packs/boxes
@@ -2061,7 +2145,7 @@ SUPPLIES
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = "/obj/structure/closet/crate/supply"
-	containername = "empty box crate"
+	containername = "\improper empty box crate"
 	group = "Supplies"
 
 /datum/supply_packs/janitor
@@ -2085,5 +2169,5 @@ SUPPLIES
 					)
 	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/supply
-	containername = "\improper Janitorial supplies crate"
+	containername = "\improper janitorial supplies crate"
 	group = "Supplies"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -4,7 +4,6 @@
 //NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
 //NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 
-#define RO_PRICE_NEAR_FREE	10
 #define RO_PRICE_VERY_CHEAP	20
 #define RO_PRICE_CHEAP		30
 #define RO_PRICE_NORMAL		40

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1,11 +1,10 @@
 //SUPPLY PACKS
 //NOTE: only secure crate types use the access var (and are lockable)
-//NOTE: hidden packs only show up when the computer has been hacked.
-//ANOTER NOTE: Contraband is obtainable through modified supplycomp circuitboards.
-//BIG NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
-//NEW NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
-//We are now moving the price of RO orders to defines, try to respect it.
+//NOTE: Contraband is obtainable through modified supplycomp circuitboards.
+//NOTE: Don't add living things to crates, that's bad, it will break the shuttle.
+//NOTE: Do NOT set the price of any crates below 7 points. Doing so allows infinite points.
 
+#define RO_PRICE_NEAR_FREE	10
 #define RO_PRICE_VERY_CHEAP	20
 #define RO_PRICE_CHEAP		30
 #define RO_PRICE_NORMAL		40
@@ -49,16 +48,14 @@ OPERATIONS
 					/obj/item/attachable/suppressor,
 					/obj/item/clothing/under/syndicate/combat,
 					/obj/item/clothing/under/syndicate/combat,
-					/obj/item/clothing/glasses/night,
-					/obj/item/clothing/glasses/night,
-					/obj/item/clothing/mask/gas/PMC,
-					/obj/item/clothing/mask/gas/PMC,
+					/obj/item/clothing/mask/gas/swat,
+					/obj/item/clothing/mask/gas/swat,
 					/obj/item/clothing/tie/storage/black_vest,
 					/obj/item/clothing/tie/storage/black_vest
 					)
-	cost = RO_PRICE_VERY_PRICY
+	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
-	containername = "spec ops crate"
+	containername = "\improper spec ops crate"
 	group = "Operations"
 
 /datum/supply_packs/beacons_supply
@@ -81,6 +78,28 @@ OPERATIONS
 	cost = RO_PRICE_PRICY
 	containertype = /obj/structure/closet/crate
 	containername = "\improper orbital beacons crate"
+	group = "Operations"
+
+/datum/supply_packs/binoculars_regular
+	name = "binoculars crate (x2)"
+	contains = list(
+					/obj/item/device/binoculars,
+					/obj/item/device/binoculars
+					)
+	cost = RO_PRICE_VERY_CHEAP
+	containertype = /obj/structure/closet/crate
+	containername = "\improper binoculars crate"
+	group = "Operations"
+
+/datum/supply_packs/binoculars_tatical
+	name = "tactical binoculars crate (x2)"
+	contains = list(
+					/obj/item/device/binoculars/tactical,
+					/obj/item/device/binoculars/tactical
+					)
+	cost = RO_PRICE_CHEAP
+	containertype = /obj/structure/closet/crate
+	containername = "\improper tactical binoculars crate"
 	group = "Operations"
 
 /datum/supply_packs/flares
@@ -111,7 +130,6 @@ OPERATIONS
 	containername = "\improper unlabeled crate"
 	contraband = 1
 	group = "Operations"
-
 
 /*******************************************************************************
 WEAPONS
@@ -1248,7 +1266,7 @@ AMMO
 					/obj/item/ammo_magazine/rifle/m4ra/impact,
 					/obj/item/ammo_magazine/rifle/m4ra/impact
 					)
-	cost = RO_PRICE_CHEAP
+	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "\improper impact scout ammo crate"
 	group = "Ammo"

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -43,18 +43,15 @@ OPERATIONS
 
 
 /datum/supply_packs/specialops
-	name = "special operations crate (operator kit x2)"
+	name = "special operations crate (operator kit x1)"
 	contains = list(
 					/obj/item/weapon/gun/pistol/b92fs/M9,
-					/obj/item/weapon/gun/pistol/b92fs/M9,
-					/obj/item/clothing/under/syndicate/combat,
+					/obj/item/ammo_magazine/pistol/b92fstranq,
 					/obj/item/clothing/under/syndicate/combat,
 					/obj/item/clothing/mask/gas/swat,
-					/obj/item/clothing/mask/gas/swat,
-					/obj/item/clothing/tie/storage/black_vest,
 					/obj/item/clothing/tie/storage/black_vest
 					)
-	cost = RO_PRICE_PRICY
+	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate
 	containername = "\improper spec ops crate"
 	group = "Operations"
@@ -82,12 +79,11 @@ OPERATIONS
 	group = "Operations"
 
 /datum/supply_packs/binoculars_regular
-	name = "binoculars crate (x2)"
+	name = "binoculars crate"
 	contains = list(
-					/obj/item/device/binoculars,
 					/obj/item/device/binoculars
 					)
-	cost = RO_PRICE_NORMAL
+	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate
 	containername = "\improper binoculars crate"
 	group = "Operations"
@@ -95,10 +91,9 @@ OPERATIONS
 /datum/supply_packs/binoculars_tatical
 	name = "tactical binoculars crate (x2)"
 	contains = list(
-					/obj/item/device/binoculars/tactical,
 					/obj/item/device/binoculars/tactical
 					)
-	cost = RO_PRICE_PRICY
+	cost = RO_PRICE_NORMAL
 	containertype = /obj/structure/closet/crate
 	containername = "\improper tactical binoculars crate"
 	group = "Operations"
@@ -1893,12 +1888,11 @@ MEDICAL
 	group = "Medical"
 
 /datum/supply_packs/surgery
-	name = "surgery crate (x2 surgical trays)"
+	name = "surgery crate (x1 surgical tray)"
 	contains = list(
-					/obj/item/storage/surgical_tray,
 					/obj/item/storage/surgical_tray
 					)
-	cost = RO_PRICE_CHEAP
+	cost = RO_PRICE_VERY_CHEAP
 	containertype = /obj/structure/closet/crate/secure/surgery
 	containername = "\improper surgery crate"
 	access = ACCESS_MARINE_MEDBAY

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -43,9 +43,6 @@
 	icon_state = "bear_mask"
 	anti_hug = 2
 
-
-
-
 //Plague Dr suit can be found in clothing/suits/bio.dm
 /obj/item/clothing/mask/gas/plaguedoctor
 	name = "plague doctor mask"
@@ -59,6 +56,8 @@
 	name = "\improper SWAT mask"
 	desc = "A close-fitting tactical mask that can be connected to an air supply."
 	icon_state = "swat"
+	anti_hug = 1
+	vision_impair = FALSE
 	siemens_coefficient = 0.7
 	flags_armor_protection = FACE|EYES
 

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -231,10 +231,11 @@
 
 /datum/ammo/bullet/pistol/tranq
 	name = "tranq bullet"
-	debilitate = list(0,2,0,0,5,3,20,0)
+	debilitate = list(0,0,0,0,5,3,30,0)
 
 /datum/ammo/bullet/pistol/hollow
 	name = "hollowpoint pistol bullet"
+
 
 /datum/ammo/bullet/pistol/hollow/New()
 	..()

--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -129,6 +129,7 @@
 	fire_delay = config.mhigh_fire_delay //to simulate manually cocking the pistol
 	accuracy_mult = config.base_hit_accuracy_mult + config.med_hit_accuracy_mult
 	accuracy_mult_unwielded = config.base_hit_accuracy_mult + config.low_hit_accuracy_mult  //for CQC
+	damage_mult = config.base_hit_damage_mult - config.max_hit_damage_mult //We don't use guns to take people down, Raiden
 
 //-------------------------------------------------------
 //DEAGLE //This one is obvious.

--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -105,7 +105,6 @@
 	item_state = "b92fs"
 	current_mag = /obj/item/ammo_magazine/pistol/b92fs
 
-
 	New()
 		..()
 		attachable_offset = list("muzzle_x" = 28, "muzzle_y" = 20,"rail_x" = 10, "rail_y" = 22, "under_x" = 21, "under_y" = 17, "stock_x" = 21, "stock_y" = 17)
@@ -118,6 +117,21 @@
 	scatter_unwielded = config.med_scatter_value
 	damage_mult = config.base_hit_damage_mult
 
+/obj/item/weapon/gun/pistol/b92fs/M9
+	name = "\improper M9 Custom pistol"
+	desc = "A 20th century military firearm customized for special forces use, fires tranq darts to take down enemies nonlethally"
+	icon_state = "b92fs"
+	item_state = "b92fs"
+	current_mag =/obj/item/ammo_magazine/pistol/b92fstranq
+	starting_attachment_types = list(
+									/obj/item/attachable/lasersight,
+									/obj/item/attachable/suppressor
+									)
+
+/obj/item/weapon/gun/pistol/b92fs/set_gun_config_values()
+	fire_delay = config.mhigh_fire_delay //to simulate manually cocking the pistol
+	accuracy_mult = config.base_hit_accuracy_mult + config.med_hit_accuracy_mult
+	accuracy_mult_unwielded = config.base_hit_accuracy_mult + config.low_hit_accuracy_mult  //for CQC
 
 //-------------------------------------------------------
 //DEAGLE //This one is obvious.
@@ -181,8 +195,6 @@
 						/obj/item/attachable/quickfire,
 						/obj/item/attachable/lasersight,
 						/obj/item/attachable/burstfire_assembly)
-
-	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK
 
 	New()//Making the gun have an invisible silencer since it's supposed to have one.
 		..()

--- a/code/modules/projectiles/updated_projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/pistols.dm
@@ -58,7 +58,6 @@
 	scatter_unwielded = config.med_scatter_value
 	damage_mult = config.base_hit_damage_mult
 
-
 /obj/item/weapon/gun/pistol/m4a3/custom
 	name = "\improper M4A3 custom pistol"
 	desc = "An M4A3 Service Pistol, the standard issue sidearm of the Colonial Marines. Uses 9mm pistol rounds. This one has an ivory-colored grip and has a slide carefully polished yearly by a team of orphan children. Looks like it belongs to a low-ranking officer."
@@ -76,7 +75,6 @@
 	scatter = config.med_scatter_value
 	scatter_unwielded = config.med_scatter_value
 	damage_mult = config.base_hit_damage_mult + config.low_hit_damage_mult
-
 
 //-------------------------------------------------------
 //M4A3 45 //Inspired by the 1911
@@ -127,7 +125,6 @@
 									/obj/item/attachable/lasersight,
 									/obj/item/attachable/suppressor
 									)
-
 /obj/item/weapon/gun/pistol/b92fs/set_gun_config_values()
 	fire_delay = config.mhigh_fire_delay //to simulate manually cocking the pistol
 	accuracy_mult = config.base_hit_accuracy_mult + config.med_hit_accuracy_mult
@@ -164,7 +161,6 @@
 		item_state = skin + item_state
 		attachable_offset = list("muzzle_x" = 31, "muzzle_y" = 21,"rail_x" = 9, "rail_y" = 23, "under_x" = 20, "under_y" = 17, "stock_x" = 20, "stock_y" = 17)
 
-
 /obj/item/weapon/gun/pistol/heavy/set_gun_config_values()
 	fire_delay = config.max_fire_delay
 	accuracy_mult = config.base_hit_accuracy_mult
@@ -174,9 +170,6 @@
 	damage_mult = config.base_hit_damage_mult + config.med_hit_damage_mult
 	recoil = config.low_recoil_value
 	recoil_unwielded = config.high_recoil_value
-
-
-
 
 //-------------------------------------------------------
 //MAUSER MERC PISTOL //Inspired by the Makarov.
@@ -196,6 +189,8 @@
 						/obj/item/attachable/lasersight,
 						/obj/item/attachable/burstfire_assembly)
 
+	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK
+
 	New()//Making the gun have an invisible silencer since it's supposed to have one.
 		..()
 		attachable_offset = list("muzzle_x" = 30, "muzzle_y" = 19,"rail_x" = 10, "rail_y" = 22, "under_x" = 21, "under_y" = 18, "stock_x" = 21, "stock_y" = 18)
@@ -214,8 +209,6 @@
 	scatter = config.med_scatter_value
 	scatter_unwielded = config.med_scatter_value
 	damage_mult = config.base_hit_damage_mult
-
-
 
 /obj/item/weapon/gun/pistol/c99/russian
 	icon_state = "pk9r"
@@ -259,7 +252,6 @@
 	damage_mult = config.base_hit_damage_mult
 	recoil = config.min_recoil_value
 	recoil_unwielded = config.med_recoil_value
-
 
 //-------------------------------------------------------
 //PIZZACHIMP PROTECTION
@@ -324,8 +316,6 @@
 	recoil = config.min_recoil_value
 	recoil_unwielded = config.med_recoil_value
 
-
-
 //-------------------------------------------------------
 //VP70 //Not actually the VP70, but it's more or less the same thing. VP70 was the standard sidearm in Aliens though.
 
@@ -382,7 +372,6 @@
 	recoil = config.min_recoil_value
 	recoil_unwielded = config.med_recoil_value
 
-
 //-------------------------------------------------------
 /*
 Auto 9 The gun RoboCop uses. A better version of the VP78, with more rounds per magazine. Probably the best pistol around, but takes no attachments.
@@ -411,8 +400,6 @@ It is a modified Beretta 93R, and can fire three round burst or single fire. Whe
 	damage_mult = config.base_hit_damage_mult
 	recoil = config.min_recoil_value
 	recoil_unwielded = config.med_recoil_value
-
-
 
 //-------------------------------------------------------
 //The first rule of monkey pistol is we don't talk about monkey pistol.

--- a/code/modules/projectiles/updated_projectiles/magazines/pistols.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/pistols.dm
@@ -56,6 +56,13 @@
 	default_ammo = /datum/ammo/bullet/pistol
 	gun_type = /obj/item/weapon/gun/pistol/b92fs
 
+/obj/item/ammo_magazine/pistol/b92fstranq
+	name = "\improper M9 tranq magazine (9mm)"
+	caliber = "9mm"
+	icon_state = "m4a3"
+	max_rounds = 12
+	default_ammo = /datum/ammo/bullet/pistol/tranq
+	gun_type = /obj/item/weapon/gun/pistol/b92fs/M9
 
 //-------------------------------------------------------
 //DEAGLE //This one is obvious.


### PR DESCRIPTION
Corrected a few typos in the list
Moved the Pyro's flamer fuel to Ammo 
Added the Semiauto Shotgun to the list of buyable crates (shotgun x1 all ammo x1 for 60 points)
Added c4 to the list of buyable crates (x5 for 60 points)
Added auto-shotty stocks to the stock attachment crate, reduced amount to 2 stocks of each type
Added Binos and Tactical Binos to the list of buyables
Separated the Scout's M4RA ammo into 3 different buyable crates
Changed the costume closets into crates (Since closets are all anchored, it's impossible to move them off the cargo pad)
Matched the actual amount of flamers and flamer tanks in a crate to what it should be according to it's description(+1 flamethrower per crate, +3 tank per crate)
Added /improper to all of the crate names and corrected a few so that it is clearer and more consistent
Made the spec-ops crate into something interesting instead of being a joke, increased it's price