### PR TITLE
Now you can quick equip your weaponary and ammo in holsters and scabbards.

### DIFF
--- a/code/__DEFINES/equipment.dm
+++ b/code/__DEFINES/equipment.dm
@@ -149,6 +149,9 @@
 #define WEAR_IN_BACK		"in_back"
 #define WEAR_IN_JACKET		"in_jacket"
 #define WEAR_IN_ACCESSORY	"in_accessory"
+#define WEAR_IN_HOLSTER		"in_holster"
+#define WEAR_IN_B_HOLSTER	"in_b_holster"
+#define WEAR_IN_J_HOLSTER	"in_j_holster"
 //=================================================
 
 // bitflags for clothing parts

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -455,7 +455,25 @@ cases. Override_icon_state should be a list.*/
 			if(WEAR_IN_BACK)
 				if (H.back && istype(H.back, /obj/item/storage/backpack))
 					var/obj/item/storage/backpack/B = H.back
-					if(B.can_be_inserted(src))
+					if(src.w_class <= B.max_w_class)
+						if(B.can_be_inserted(src))
+							return 1
+			if(WEAR_IN_B_HOLSTER)
+				if (H.back && istype(H.back, /obj/item/storage/large_holster))
+					var/obj/item/storage/S = H.back
+					if(S.can_be_inserted(src))
+						return 1
+				return 0
+			if(WEAR_IN_HOLSTER)
+				if((H.belt && istype(H.belt,/obj/item/storage/large_holster)) || (H.belt && istype(H.belt,/obj/item/storage/belt/gun)))
+					var/obj/item/storage/S = H.belt
+					if(S.can_be_inserted(src))
+						return 1
+				return 0
+			if(WEAR_IN_J_HOLSTER)
+				if((H.s_store && istype(H.s_store, /obj/item/storage/large_holster)) ||(H.s_store && istype(H.s_store,/obj/item/storage/belt/gun)))
+					var/obj/item/storage/S = H.s_store
+					if(S.can_be_inserted(src))
 						return 1
 				return 0
 		return 0 //Unsupported slot

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -77,6 +77,12 @@
 			return 1
 		if(WEAR_IN_ACCESSORY)
 			return 1
+		if(WEAR_IN_HOLSTER)
+			return 1
+		if(WEAR_IN_J_HOLSTER)
+			return 1
+		if(WEAR_IN_B_HOLSTER)
+			return 1
 
 /mob/living/carbon/human/put_in_l_hand(obj/item/W)
 	var/datum/limb/O = get_limb("l_hand")
@@ -327,9 +333,8 @@
 			W.equipped(src, slot)
 			update_inv_s_store()
 		if(WEAR_IN_BACK)
-			if(get_active_hand() == W)
-				temp_drop_inv_item(W)
-			W.forceMove(back)
+			var/obj/item/storage/S = back
+			S.handle_item_insertion(W, 0, src)
 		if(WEAR_IN_JACKET)
 			var/obj/item/clothing/suit/storage/S = wear_suit
 			if(istype(S) && S.pockets.storage_slots) W.loc = S.pockets//Has to have some slots available.
@@ -339,6 +344,18 @@
 			if(U && U.hastie)
 				var/obj/item/clothing/tie/storage/T = U.hastie
 				if(istype(T) && T.hold.storage_slots) W.loc = T.hold
+
+		if(WEAR_IN_HOLSTER)
+			var/obj/item/storage/S = belt
+			S.handle_item_insertion(W, 0, src)
+
+		if(WEAR_IN_B_HOLSTER)
+			var/obj/item/storage/S = s_store
+			S.handle_item_insertion(W, 0, src)
+
+		if(WEAR_IN_J_HOLSTER)
+			var/obj/item/storage/S = s_store
+			S.handle_item_insertion(W, 0, src)
 
 		else
 			to_chat(src, "\red You are trying to eqip this item to an unsupported inventory slot. How the heck did you manage that? Stop it...")

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -350,7 +350,7 @@
 			S.handle_item_insertion(W, 0, src)
 
 		if(WEAR_IN_B_HOLSTER)
-			var/obj/item/storage/S = s_store
+			var/obj/item/storage/S = back
 			S.handle_item_insertion(W, 0, src)
 
 		if(WEAR_IN_J_HOLSTER)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -816,5 +816,10 @@
 
 	if(WEAR_BACK in equip_slots)
 		equip_slots |= WEAR_IN_BACK
+	if(WEAR_WAIST in equip_slots)
+		equip_slots |= WEAR_IN_HOLSTER
+	if(WEAR_JACKET in equip_slots)
+		equip_slots |= WEAR_IN_J_HOLSTER
 
 	equip_slots |= WEAR_LEGCUFFS
+	equip_slots |= WEAR_IN_B_HOLSTER

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -196,7 +196,10 @@ var/list/slot_equipment_priority = list( \
 		WEAR_WAIST,\
 		WEAR_J_STORE,\
 		WEAR_L_STORE,\
-		WEAR_R_STORE\
+		WEAR_R_STORE,\
+		WEAR_IN_HOLSTER,\
+		WEAR_IN_J_HOLSTER,\
+		WEAR_IN_B_HOLSTER\
 	)
 
 //puts the item "W" into an appropriate slot in a human's inventory


### PR DESCRIPTION
Now you can just press E to equip your weapons and ammo to an appropriate holster/scabbard.

As a gamer, I don't really like the lack of quick storaging for all containers, but on the other hand that would null the little comfort this PR adds to holsters and the distasteful large holsters. I don't enjoy this code too much, but it works.