### PR TITLE
 StaggerStun Proc + Shotgun Munition Rework

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -595,7 +595,7 @@
 	accuracy_var_low = config.med_proj_variance
 	accuracy_var_high = config.med_proj_variance
 	max_range = config.short_shell_range
-	damage = config.hlow_hit_damage
+	damage = config.hmed_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
 	damage_falloff *= 0.5

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -571,7 +571,7 @@
 	damage = config.hlow_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
-	damage_falloff = reg_damage_falloff * 0.75
+	damage_falloff *= 0.75
 	penetration	= config.high_armor_penetration
 	bonus_projectiles_amount = config.low_proj_extra
 
@@ -587,7 +587,7 @@
 	damage = config.hlow_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
-	damage_falloff = reg_damage_falloff * 0.75
+	damage_falloff *= 0.75
 	penetration	= config.high_armor_penetration
 	scatter = config.max_scatter_value //bonus projectiles run their own scatter chance
 

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -580,7 +580,7 @@
 	accuracy_var_low = config.med_proj_variance
 	accuracy_var_high = config.med_proj_variance
 	max_range = config.short_shell_range
-	damage = config.hmed_hit_damage
+	damage = config.lmed_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
 	damage_falloff *= 0.5
@@ -596,7 +596,7 @@
 	accuracy_var_low = config.med_proj_variance
 	accuracy_var_high = config.med_proj_variance
 	max_range = config.short_shell_range
-	damage = config.hmed_hit_damage
+	damage = config.lmed_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
 	damage_falloff *= 0.5

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -580,7 +580,7 @@
 	accuracy_var_low = config.med_proj_variance
 	accuracy_var_high = config.med_proj_variance
 	max_range = config.short_shell_range
-	damage = config.lmed_hit_damage
+	damage = config.med_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
 	damage_falloff *= 0.5

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -100,40 +100,51 @@
 						to_chat(target, "<span class='highdanger'>The blast knocks you off your feet!</span>")
 			step_away(M,P)
 
-	proc/staggerstun(mob/M, obj/item/projectile/P, var/max_range = 2, var/stun = 0, var/weaken = 1, var/stagger = 2, var/slowdown = 1, var/knockback = 1, var/size_threshold = 2, var/shake = 1)
+	proc/staggerstun(mob/M, obj/item/projectile/P, var/max_range = 2, var/stun = 0, var/weaken = 1, var/stagger = 2, var/slowdown = 1, var/knockback = 1, var/shake = 1, var/soft_size_threshold = 3, var/hard_size_threshold = 2)
 		if(!M || M == P.firer)
 			return
 		if(shake && (P.distance_travelled > max_range || M.lying))
 			shake_camera(M, shake+1, shake)
 			return
-		if(!isliving(M) || (isYautja(M) && size_threshold < 4) || (M.mob_size == MOB_SIZE_BIG && size_threshold < 3) || (isXeno(M) && size_threshold < 2) || ( ishuman(M) && size_threshold < 1))
+		if(!isliving(M))
 			return
+		var/impact_message = ""
 		if(shake)
 			shake_camera(M, shake+2, shake+3)
-		if(isXeno(M))
-			var/mob/living/carbon/Xenomorph/target = M
-			target.apply_effects(stun,weaken)
+			if(isXeno(M))
+				impact_message += "<span class='xenodanger'>You are shaken by the sudden impact!</span>"
+			else
+				impact_message += "<span class='warning'>You are shaken by the sudden impact!</span>"
+		//Check for and apply hard CC.
+		if(((isYautja(M) || M.mob_size == MOB_SIZE_BIG) && hard_size_threshold > 2) || (M.mob_size == MOB_SIZE_XENO && hard_size_threshold > 1) || (ishuman(M) && hard_size_threshold > 0))
+			var/mob/living/L = M
+			L.apply_effects(stun,weaken)
+			if(knockback)
+				if(isXeno(M))
+					impact_message += "<span class='xenodanger'>The blast knocks you off your feet!</span>"
+				else
+					impact_message += "<span class='highdanger'>The blast knocks you off your feet!</span>"
+				for(var/i=0, i<knockback, i++)
+					step_away(M,P)
+
+		//Check for and apply soft CC; Xeno only at this time
+		if(isXeno(M) && (M.mob_size == MOB_SIZE_BIG && soft_size_threshold > 2) || (M.mob_size == MOB_SIZE_XENO && soft_size_threshold > 1))
+			var/mob/living/carbon/Xenomorph/X = M
 			#if DEBUG_STAGGER_SLOWDOWN
 			to_chat(world, "<span class='debuginfo'>Damage: Initial stagger is: <b>[target.stagger]</b></span>")
 			#endif
-			target.adjust_stagger(stagger)
+			X.adjust_stagger(stagger)
 			#if DEBUG_STAGGER_SLOWDOWN
 			to_chat(world, "<span class='debuginfo'>Damage: Final stagger is: <b>[target.stagger]</b></span>")
 			#endif
 			#if DEBUG_STAGGER_SLOWDOWN
 			to_chat(world, "<span class='debuginfo'>Damage: Initial slowdown is: <b>[target.slowdown]</b></span>")
 			#endif
-			target.add_slowdown(slowdown)
+			X.add_slowdown(slowdown)
 			#if DEBUG_STAGGER_SLOWDOWN
 			to_chat(world, "<span class='debuginfo'>Damage: Final slowdown is: <b>[target.slowdown]</b></span>")
 			#endif
-			to_chat(target, "<span class='xenodanger'>You are shaken by the sudden impact!</span>")
-		else
-			var/mob/living/target = M
-			target.apply_effects(stun,weaken)
-			to_chat(target, "<span class='highdanger'>The blast knocks you off your feet!</span>")
-		for(var/i=0, i<knockback, i++)
-			step_away(M,P)
+		to_chat(M, "[impact_message]") //Summarize all the bad shit that happened
 
 	proc/burst(atom/target, obj/item/projectile/P, damage_type = BRUTE)
 		if(!target || !P)

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -508,7 +508,7 @@
 	penetration= config.low_armor_penetration
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/item/projectile/P)
-	staggerstun(M, P, config.close_shell_range, 0, 1, 2, 2)
+	staggerstun(M, P, config.close_shell_range, 0, 1, 4, 4)
 
 
 /datum/ammo/bullet/shotgun/beanbag
@@ -568,10 +568,10 @@
 	accuracy_var_low = config.med_proj_variance
 	accuracy_var_high = config.med_proj_variance
 	max_range = config.short_shell_range
-	damage = config.hlow_hit_damage
+	damage = config.hmed_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
-	damage_falloff *= 0.75
+	damage_falloff *= 0.5
 	penetration	= config.high_armor_penetration
 	bonus_projectiles_amount = config.low_proj_extra
 
@@ -587,7 +587,7 @@
 	damage = config.hlow_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
-	damage_falloff *= 0.75
+	damage_falloff *= 0.5
 	penetration	= config.high_armor_penetration
 	scatter = config.max_scatter_value //bonus projectiles run their own scatter chance
 

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -118,7 +118,8 @@
 		//Check for and apply hard CC.
 		if(((isYautja(M) || M.mob_size == MOB_SIZE_BIG) && hard_size_threshold > 2) || (M.mob_size == MOB_SIZE_XENO && hard_size_threshold > 1) || (ishuman(M) && hard_size_threshold > 0))
 			var/mob/living/L = M
-			L.apply_effects(stun,weaken)
+			if(!M.stunned && !M.knocked_down) //Prevent chain stunning.
+				L.apply_effects(stun,weaken)
 			if(knockback)
 				if(isXeno(M))
 					impact_message += "<span class='xenodanger'>The blast knocks you off your feet!</span>"

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -519,7 +519,7 @@
 	penetration= config.low_armor_penetration
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/M,obj/item/projectile/P)
-	staggerstun(M, P, config.close_shell_range, 0, 1, 4, 4)
+	staggerstun(M, P, config.close_shell_range, 0, 1, 8, 8)
 
 
 /datum/ammo/bullet/shotgun/beanbag

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -571,6 +571,7 @@
 	damage = config.hlow_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
+	damage_falloff = reg_damage_falloff * 0.75
 	penetration	= config.high_armor_penetration
 	bonus_projectiles_amount = config.low_proj_extra
 
@@ -586,8 +587,9 @@
 	damage = config.hlow_hit_damage
 	damage_var_low = -config.low_proj_variance
 	damage_var_high = config.low_proj_variance
+	damage_falloff = reg_damage_falloff * 0.75
 	penetration	= config.high_armor_penetration
-	scatter = config.max_scatter_value*2 //bonus projectiles run their own scatter chance
+	scatter = config.max_scatter_value //bonus projectiles run their own scatter chance
 
 /datum/ammo/bullet/shotgun/buckshot
 	name = "shotgun buckshot shell"


### PR DESCRIPTION
-StaggerStun Proc reworked to differentiate between hard CC and soft CC, featuring different requisite variables for each. Soft CC (slowdown and ability lock) now works on all castes by default.

Further, targets that are already stunned/knocked down can't be stunned/knocked down by the Staggerstun proc.

-Slug support aspects improved; slow and stagger soft CC effects increased to 8 each up from 2.

-After playtesting flechettes determined as needing further improvement, thus:
1. Flechette falloff reduced by 50%; -0.5 damage per tile down from -1 per tile.
2. Damage increased for each flechette projectile to 40 up from 35.
3. Max range for secondary flechettes increased to 10 (not sure why it was reduced to 5).
4. Flechette scatter chance for secondary flechettes reduced to 40% from 80%.