### PR TITLE
Smartgun Improvement

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -54,7 +54,7 @@
 	toggleable = 1
 	actions_types = list(/datum/action/item_action/toggle)
 	vision_flags = SEE_TURFS
-	//fullscreen_vision = /obj/screen/fullscreen/thermal //Commented out due to general dislike for the overlay.
+	fullscreen_vision = null //Nulled out due to general dislike for the overlay.
 
 /obj/item/clothing/glasses/night/m56_goggles/mob_can_equip(mob/user, slot)
 	if(slot == WEAR_EYES)

--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -54,7 +54,7 @@
 	toggleable = 1
 	actions_types = list(/datum/action/item_action/toggle)
 	vision_flags = SEE_TURFS
-	fullscreen_vision = /obj/screen/fullscreen/thermal
+	//fullscreen_vision = /obj/screen/fullscreen/thermal //Commented out due to general dislike for the overlay.
 
 /obj/item/clothing/glasses/night/m56_goggles/mob_can_equip(mob/user, slot)
 	if(slot == WEAR_EYES)

--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -122,7 +122,7 @@
 		playsound(user, 'sound/weapons/unload.ogg', 25, 1)
 
 		reloading = FALSE
-		return 1
+		return TRUE
 
 /obj/item/smartgun_powerpack/proc/autoload_check(mob/user, delay, obj/item/weapon/gun/smartgun/mygun, obj/item/smartgun_powerpack/powerpack, numticks = 5)
 	if(!istype(user) || delay <= 0) return FALSE

--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -31,7 +31,7 @@
 	var/rounds_remaining = 500
 	var/rounds_max = 500
 	actions_types = list(/datum/action/item_action/toggle)
-	var/reloading = 0
+	var/reloading = FALSE
 
 	New()
 		select_gamemode_skin(/obj/item/smartgun_powerpack)
@@ -61,7 +61,7 @@
 			to_chat(user, "Your powerpack's battery is too drained! Get a new battery and install it!")
 			return
 
-		reloading = 1
+		reloading = TRUE
 		if(!automatic)
 			user.visible_message("[user.name] begins feeding an ammo belt into the M56 Smartgun.","You begin feeding a fresh ammo belt into the M56 Smartgun. Don't move or you'll be interrupted.")
 		else
@@ -75,7 +75,7 @@
 			else
 				to_chat(user, "Your reloading was interrupted!")
 				playsound(src,'sound/machines/buzz-two.ogg', 25, 1)
-				reloading = 0
+				reloading = FALSE
 				return
 		else
 			if(autoload_check(user, reload_duration, mygun, src))
@@ -83,7 +83,7 @@
 			else
 				to_chat(user, "The automated reload process was interrupted!")
 				playsound(src,'sound/machines/buzz-two.ogg', 25, 1)
-				reloading = 0
+				reloading = FALSE
 				return
 		return 1
 
@@ -121,7 +121,7 @@
 		else	to_chat(user, "The powerpack servos finish loading [rounds_to_reload] shells into the M56 Smartgun. Ready to rumble!")
 		playsound(user, 'sound/weapons/unload.ogg', 25, 1)
 
-		reloading = 0
+		reloading = FALSE
 		return 1
 
 /obj/item/smartgun_powerpack/proc/autoload_check(mob/user, delay, obj/item/weapon/gun/smartgun/mygun, obj/item/smartgun_powerpack/powerpack, numticks = 5)

--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -137,7 +137,7 @@
 		if(!user)
 			. = FALSE
 			break
-		if(!(L.back == powerpack) || !(L.s_store == mygun) && !(user.get_active_hand() == mygun)) //power pack and gun aren't where they should be.
+		if(!(L.s_store == mygun) && !(user.get_active_hand() == mygun) && !(user.get_inactive_hand() == mygun) || !(L.back == powerpack)) //power pack and gun aren't where they should be.
 			. = FALSE
 			break
 

--- a/code/modules/cm_marines/equipment/weapons.dm
+++ b/code/modules/cm_marines/equipment/weapons.dm
@@ -63,7 +63,7 @@
 
 		reloading = 1
 		if(!automatic)
-			user.visible_message("[user.name] begin feeding an ammo belt into the M56 Smartgun.","You begin feeding a fresh ammo belt into the M56 Smartgun. Don't move or you'll be interrupted.")
+			user.visible_message("[user.name] begins feeding an ammo belt into the M56 Smartgun.","You begin feeding a fresh ammo belt into the M56 Smartgun. Don't move or you'll be interrupted.")
 		else
 			user.visible_message("[user.name]'s powerpack servos begin automatically feeding an ammo belt into the M56 Smartgun.","The powerpack servos begin automatically feeding a fresh ammo belt into the M56 Smartgun.")
 		var/reload_duration = 50

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -725,7 +725,7 @@
 	..()
 	accurate_range = config.short_shell_range
 	damage = config.low_hit_damage
-	penetration= config.med_armor_penetration
+	penetration= config.low_armor_penetration
 
 /datum/ammo/bullet/smartgun/lethal
 	flags_ammo_behavior = AMMO_BALLISTIC

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -725,7 +725,7 @@
 	..()
 	accurate_range = config.short_shell_range
 	damage = config.low_hit_damage
-	penetration= config.mlow_armor_penetration
+	penetration= config.med_armor_penetration
 
 /datum/ammo/bullet/smartgun/lethal
 	flags_ammo_behavior = AMMO_BALLISTIC

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -203,12 +203,16 @@
 	wield_delay = 16
 	aim_slowdown = SLOWDOWN_ADS_SPECIALIST
 	var/datum/ammo/ammo_secondary = /datum/ammo/bullet/smartgun/lethal//Toggled ammo type
-	var/shells_fired_max = 20 //Smartgun only; once you fire # of shells, it will attempt to reload automatically. If you start the reload, the counter resets.
+	var/shells_fired_max = 50 //Smartgun only; once you fire # of shells, it will attempt to reload automatically. If you start the reload, the counter resets.
 	var/shells_fired_now = 0 //The actual counter used. shells_fired_max is what it is compared to.
 	var/restriction_toggled = 1 //Begin with the safety on.
 	gun_skill_category = GUN_SKILL_SMARTGUN
 	attachable_allowed = list(
+						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/heavy_barrel,
+						/obj/item/attachable/reddot,
+						/obj/item/attachable/flashlight,
+						/obj/item/attachable/lasersight,
 						/obj/item/attachable/burstfire_assembly,
 						/obj/item/attachable/bipod)
 
@@ -218,7 +222,7 @@
 /obj/item/weapon/gun/smartgun/New()
 	..()
 	ammo_secondary = ammo_list[ammo_secondary]
-	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 16,"rail_x" = 17, "rail_y" = 19, "under_x" = 22, "under_y" = 14, "stock_x" = 22, "stock_y" = 14)
+	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 16,"rail_x" = 17, "rail_y" = 17, "under_x" = 22, "under_y" = 14, "stock_x" = 22, "stock_y" = 14)
 
 
 /obj/item/weapon/gun/smartgun/set_gun_config_values()
@@ -228,6 +232,7 @@
 	accuracy_mult = config.base_hit_accuracy_mult + config.min_hit_accuracy_mult
 	scatter = config.med_scatter_value
 	damage_mult = config.base_hit_damage_mult
+	damage_falloff_mult = config.med_damage_falloff_mult
 
 /obj/item/weapon/gun/smartgun/examine(mob/user)
 	..()
@@ -277,7 +282,7 @@
 	set waitfor = 0
 	sleep(5)
 	if(power_pack && power_pack.loc)
-		power_pack.attack_self(smart_gunner)
+		power_pack.attack_self(smart_gunner, TRUE)
 
 /obj/item/weapon/gun/smartgun/dirty
 	name = "\improper M56D 'dirty' smartgun"

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -211,12 +211,11 @@
 						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/heavy_barrel,
 						/obj/item/attachable/flashlight,
-						/obj/item/attachable/lasersight,
 						/obj/item/attachable/burstfire_assembly,
 						/obj/item/attachable/bipod)
 
 	flags_gun_features = GUN_INTERNAL_MAG|GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
-
+	starting_attachment_types = list(/obj/item/attachable/flashlight)
 
 /obj/item/weapon/gun/smartgun/New()
 	..()

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -216,7 +216,7 @@
 						/obj/item/attachable/burstfire_assembly,
 						/obj/item/attachable/bipod)
 
-	flags_gun_features = GUN_INTERNAL_MAG|GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY
+	flags_gun_features = GUN_INTERNAL_MAG|GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY|GUN_AMMO_COUNTER
 
 
 /obj/item/weapon/gun/smartgun/New()

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -210,7 +210,6 @@
 	attachable_allowed = list(
 						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/heavy_barrel,
-						/obj/item/attachable/reddot,
 						/obj/item/attachable/flashlight,
 						/obj/item/attachable/lasersight,
 						/obj/item/attachable/burstfire_assembly,

--- a/code/modules/projectiles/updated_projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/specialist.dm
@@ -83,7 +83,7 @@
 /obj/item/ammo_magazine/internal/smartgun
 	name = "integrated smartgun belt"
 	caliber = "10x28mm"
-	max_rounds = 50 //Should be 500 in total.
+	max_rounds = 100
 	default_ammo = /datum/ammo/bullet/smartgun
 
 


### PR DESCRIPTION
Ammo Capacity: 500 pack and 100 belt. Up from 250 and 50.

 AP 30 up from 10 so it can actually deal with decent armour, instead of plinking it for barely any damage.

Falloff damage reduction per tile -0.5 down from -1 so it doesn't lose 10-20% of its already low base damage for being backline as it should be.

Can now take the following attachments:
* Extended Barrel
* Flashlight (Starts with this by default)

Automatic reload system actually works on the move as god intended, but always does so at the slowest speed because skills don't apply.

Removed the thermals overlay for the SG visor since no one liked it, and it hurt peoples' eyes Virtua Boy style.