### PR TITLE
Refactors(?) coins and tokens interaction with vendors.

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -134,4 +134,4 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define TOKEN_MARINE			2
 #define TOKEN_ENGI				4
 #define TOKEN_SPEC				8
-#define TOKEN_ALL				16
+#define TOKEN_ALL				15

--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -127,3 +127,11 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define IS_PRY_CAPABLE_CROWBAR		2 //actual crowbar
 #define IS_PRY_CAPABLE_FORCE		3 //can force open even powered airlocks
 
+//flags_token & tokensupport
+//used for coins and vendors, restricting specific tokens to associated vendors.
+
+#define TOKEN_GENERAL			1
+#define TOKEN_MARINE			2
+#define TOKEN_ENGI				4
+#define TOKEN_SPEC				8
+#define TOKEN_ALL				16

--- a/code/game/machinery/vending/marine_vending.dm
+++ b/code/game/machinery/vending/marine_vending.dm
@@ -14,6 +14,7 @@
 	req_one_access = null
 	req_one_access_txt = "9;2;21"
 	wrenchable = FALSE
+	tokensupport = TOKEN_MARINE
 
 	product_ads = "If it moves, it's hostile!;How many enemies have you killed today?;Shoot first, perform autopsy later!;Your ammo is right here.;Guns!;Die, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a donut?"
 	products = list(
@@ -363,6 +364,7 @@
 	icon_state = "boozeomat"
 	icon_deny = "boozeomat-deny"
 	wrenchable = FALSE
+	tokensupport = TOKEN_SPEC
 
 	products = list(
 						/obj/item/coin/marine = 1,
@@ -397,9 +399,10 @@
 	icon_state = "boozeomat"
 	icon_deny = "boozeomat-deny"
 	wrenchable = FALSE
+	tokensupport = TOKEN_SPEC
 
 	products = list(
-						/obj/item/coin/marine = 1,
+						/obj/item/coin/marine/specialist = 1,
 			)
 	contraband = list()
 	//premium = list(/obj/item/weapon/shield/riot = 1)	//NOTE: This needs to be re-worked so we don't have to have a riot shield in here at all. ~Bmc777
@@ -429,6 +432,8 @@
 	icon_state = "tool"
 	icon_deny = "tool-deny"
 	wrenchable = FALSE
+	tokensupport = TOKEN_ENGI
+
 	products = list(
 					/obj/item/coin/marine/engineer = 1,
 					)
@@ -482,6 +487,7 @@
 	icon_state = "tool"
 	icon_deny = "tool-deny"
 	wrenchable = FALSE
+	tokensupport = "marine"
 
 	products = list(
 						/obj/item/clothing/suit/storage/marine/leader = 1,
@@ -530,6 +536,7 @@
 	icon_state = "robotics"
 	icon_deny = "robotics-deny"
 	wrenchable = FALSE
+	tokensupport = "marine"
 
 	products = list(
 						/obj/item/attachable/suppressor = 8,

--- a/code/game/machinery/vending/marine_vending.dm
+++ b/code/game/machinery/vending/marine_vending.dm
@@ -367,7 +367,7 @@
 	tokensupport = TOKEN_SPEC
 
 	products = list(
-						/obj/item/coin/marine = 1,
+						/obj/item/coin/marine/specialist = 1,
 						/obj/item/clothing/tie/storage/webbing = 1,
 						/obj/item/explosive/plastique = 2,
 						/obj/item/explosive/grenade/frag = 2,

--- a/code/game/machinery/vending/vending.dm
+++ b/code/game/machinery/vending/vending.dm
@@ -174,10 +174,10 @@
 		if(coin)
 			to_chat(user, "<span class='warning'>[src] already has [coin] inserted</span>")
 			return
-		if(!premium.len && !istype(src,/obj/machinery/vending/shared_vending))
+		if(!premium.len && !isshared)
 			to_chat(user, "<span class='warning'>[src] doesn't have a coin slot.</span>")
 			return
-		if(C.flags_token & tokensupport || C.flags_token & TOKEN_ALL)
+		if(C.flags_token & tokensupport)
 			if(user.drop_inv_item_to_loc(W, src))
 				coin = W
 				to_chat(user, "\blue You insert the [W] into the [src]")

--- a/code/game/machinery/vending/vending.dm
+++ b/code/game/machinery/vending/vending.dm
@@ -56,6 +56,7 @@
 	var/panel_open = 0 //Hacking that vending machine. Gonna get a free candy bar.
 	var/wires = 15
 	var/obj/item/coin/coin
+	var/tokensupport = TOKEN_GENERAL
 	var/const/WIRE_EXTEND = 1
 	var/const/WIRE_SCANID = 2
 	var/const/WIRE_SHOCK = 3
@@ -168,9 +169,20 @@
 			attack_hand(user)
 		return
 	else if(istype(W, /obj/item/coin))
-		if(user.drop_inv_item_to_loc(W, src))
-			coin = W
-			to_chat(user, "\blue You insert the [W] into the [src]")
+		var/obj/item/coin/C = W
+		if(coin)
+			to_chat(user, "<span class='warning'>[src] already has [coin] inserted</span>")
+			return
+		if(!premium.len)
+			to_chat(user, "<span class='warning'>[src] doesn't have a coin slot.</span>")
+			return
+		if(C.flags_token & tokensupport || C.flags_token & TOKEN_ALL)
+			if(user.drop_inv_item_to_loc(W, src))
+				coin = W
+				to_chat(user, "\blue You insert the [W] into the [src]")
+		else
+			to_chat(user, "<span class='warning'>\The [src] rejects the [W].</span>")
+			return
 		return
 	else if(istype(W, /obj/item/card))
 		var/obj/item/card/I = W

--- a/code/game/machinery/vending/vending.dm
+++ b/code/game/machinery/vending/vending.dm
@@ -67,6 +67,7 @@
 	var/tipped_level = 0
 	var/hacking_safety = 0 //1 = Will never shoot inventory or allow all access
 	var/wrenchable = TRUE
+	var/isshared = FALSE
 
 /obj/machinery/vending/New()
 	..()
@@ -173,7 +174,7 @@
 		if(coin)
 			to_chat(user, "<span class='warning'>[src] already has [coin] inserted</span>")
 			return
-		if(!premium.len)
+		if(!premium.len && !istype(src,/obj/machinery/vending/shared_vending))
 			to_chat(user, "<span class='warning'>[src] doesn't have a coin slot.</span>")
 			return
 		if(C.flags_token & tokensupport || C.flags_token & TOKEN_ALL)
@@ -389,6 +390,7 @@
 		"ewallet_worth" = ewallet ? ewallet.worth : null,
 		"coin" = coin ? coin.name : null,
 		"displayed_records" = display_list,
+		"isshared" = isshared
 	)
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/code/game/machinery/vending/vending_types.dm
+++ b/code/game/machinery/vending/vending_types.dm
@@ -381,6 +381,7 @@
 /obj/machinery/vending/shared_vending
 	var/list/shared = list()
 	var/static/list/shared_products = list()
+	isshared = TRUE
 
 /obj/machinery/vending/shared_vending/New()
 	..()

--- a/code/game/objects/items/devices/coins.dm
+++ b/code/game/objects/items/devices/coins.dm
@@ -10,6 +10,7 @@
 	w_class = 1.0
 	var/string_attached
 	var/sides = 2
+	var/flags_token = TOKEN_GENERAL
 
 /obj/item/coin/New()
 	pixel_x = rand(0,16)-8
@@ -42,6 +43,12 @@
 /obj/item/coin/platinum
 	name = "platinum coin"
 	icon_state = "coin_adamantine"
+
+/obj/item/coin/debugtoken
+	name = "prototype universal token"
+	desc = "A special nano-fiber chip, emblazed with several minuscule tags. Rarely ever seen outside emergency maintenance situations."
+	icon_state = "coin_clown"
+	flags_token = TOKEN_ALL
 
 /obj/item/coin/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack/cable_coil))

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -46,15 +46,19 @@
 	item_path = /obj/item/bodybag/tarp/snow
 
 
-
-
 /obj/item/coin/marine
+	name = "marine premium token"
+	desc = "A special coin meant to be inserted in a marine vendor in order to access a single premium equipment or device... or just to suffice your vices."
+	icon_state = "coin_adamantine"
+	flags_token = TOKEN_MARINE|TOKEN_GENERAL //when you do prefer a premium smoke over else.
+
+/obj/item/coin/marine/attackby(obj/item/W as obj, mob/user as mob) //To remove attaching a string functionality
+	return
+
+/obj/item/coin/marine/specialist
 	name = "marine specialist weapon token"
 	desc = "Insert this into a specialist vendor in order to access a single highly dangerous weapon."
-	icon_state = "coin_adamantine"
-
-	attackby(obj/item/W as obj, mob/user as mob) //To remove attaching a string functionality
-		return
+	flags_token = TOKEN_SPEC
 
 /obj/structure/broken_apc
 	name = "\improper M577 armored personnel carrier"

--- a/code/modules/cm_marines/smartgun_mount.dm
+++ b/code/modules/cm_marines/smartgun_mount.dm
@@ -4,8 +4,8 @@
 //Adds a coin for engi vendors
 /obj/item/coin/marine/engineer
 	name = "marine engineer support token"
-	desc = "Insert this into a engineer vendor in order to access a support weapon."
-	icon_state = "coin_adamantine"
+	desc = "Insert this into a engineer vendor in order to access a support artillery weapon."
+	flags_token = TOKEN_ENGI
 
 // First thing we need is the ammo drum for this thing.
 /obj/item/ammo_magazine/m56d

--- a/nano/templates/vending_machine.tmpl
+++ b/nano/templates/vending_machine.tmpl
@@ -7,13 +7,14 @@
 	</div>
 {{else}}
 	<div itemLabel>
-		{{if data.premium_length > 0}}
+		{{if data.premium_length > 0}} {{else data.isshared}}
 			{{if data.coin}}
 				<b>Coin slot:</b> {{:helper.link('Remove', null, {'remove_coin' : '1'}, null, null)}}
 			{{else}}
 				<b>Coin slot:</b> No coin inserted
 			{{/if}}
 		{{/if}}
+		
 	</div>
 	<div itemLabel>
 		{{if data.ewallet}}

--- a/nano/templates/vending_machine.tmpl
+++ b/nano/templates/vending_machine.tmpl
@@ -7,9 +7,15 @@
 	</div>
 {{else}}
 	<div itemLabel>
-		{{if data.premium_length > 0}} {{else data.isshared}}
+		{{if data.premium_length > 0}}
 			{{if data.coin}}
-				<b>Coin slot:</b> {{:helper.link('Remove', null, {'remove_coin' : '1'}, null, null)}}
+				<b>Coin slot:</b> {{:data.coin}} {{:helper.link('Remove', null, {'remove_coin' : '1'}, null, null)}}
+			{{else}}
+				<b>Coin slot:</b> No coin inserted
+			{{/if}}
+		{{else data.isshared}}
+			{{if data.coin}}
+				<b>Coin slot:</b> {{:data.coin}} {{:helper.link('Remove', null, {'remove_coin' : '1'}, null, null)}}
 			{{else}}
 				<b>Coin slot:</b> No coin inserted
 			{{/if}}


### PR DESCRIPTION
Added in token flags for coins and vendors. They are used to prevent special coins from being inserted in unsupported vendors and special vendors accepting any coin.
This makes coins and future ideaguys projects viable without repercussion of exploits, and may stops a dumb engineer from wasting its token on an empty ol M4A1 or a cigar case. (also fixes a bug or two... or three)