### PR TITLE
flamers and boiler spray now reset their values on already affected turfs...

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -120,11 +120,16 @@
 			cdel(src)
 		return
 
-proc/flame_radius(radius = 1, turf/turf) //~Art updated fire.
-	if(!turf || !isturf(turf)) return
-	if(radius < 0) radius = 0
-	if(radius > 5) radius = 5
-	new /obj/flamer_fire(turf, 5 + rand(0,11), 15, null, radius)
+proc/flame_radius(radius = 1, turf/T) //~Art updated fire.
+	if(!T || !isturf(T))
+		return
+	if(radius < 0)
+		radius = 0
+	if(radius > 5)
+		radius = 5
+	for(var/obj/flamer_fire/F in range(radius,T)) // No stacking flames!
+		cdel(F)
+	new /obj/flamer_fire(T, 5 + rand(0,11), 15, null, radius)
 
 
 /obj/item/explosive/grenade/incendiary/molotov

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -188,8 +188,9 @@
 		L.adjustFireLoss(120)
 		L.adjust_fire_stacks(20)
 		L.IgniteMob()
-	if(!locate(/obj/flamer_fire) in T)
-		new/obj/flamer_fire(T, 5, 30) //short but intense
+	for(var/obj/flamer_fire/F in T) // No stacking flames!
+		cdel(F)
+	new/obj/flamer_fire(T, 5, 30) //short but intense
 
 
 //Rockets
@@ -293,8 +294,9 @@
 		spawn(5)
 			explosion(impact,1,2,3,6,1,0) //relatively weak
 			for(var/turf/T in range(4,impact))
-				if(!locate(/obj/flamer_fire) in T) // No stacking flames!
-					new/obj/flamer_fire(T, 60, 30) //cooking for a long time
+				for(var/obj/flamer_fire/F in T) // No stacking flames!
+					cdel(F)
+				new/obj/flamer_fire(T, 60, 30) //cooking for a long time
 			cdel(src)
 
 
@@ -346,9 +348,9 @@
 	detonate_on(turf/impact)
 		..()
 		spawn(5)
-			for(var/turf/T in range(2, impact))
-				if(!locate(/obj/flamer_fire) in T) // No stacking flames!
-					new/obj/flamer_fire(T)
+			for(var/obj/flamer_fire/F in impact) // No stacking flames!
+				cdel(F)
+			new/obj/flamer_fire(impact)
 
 /obj/structure/ship_ammo/minirocket/illumination
 	name = "illumination rocket-launched flare stack"
@@ -369,7 +371,7 @@
 			S.set_up(1,0,T,null)
 			S.start()
 		spawn(10)
-			new/obj/item/device/flashlight/flare/on/cas(T) 
+			new/obj/item/device/flashlight/flare/on/cas(T)
 		if(!ammo_count && loc)
 			cdel(src) //deleted after last minirocket is fired and impact the ground.
 

--- a/code/modules/cm_marines/orbital_cannon.dm
+++ b/code/modules/cm_marines/orbital_cannon.dm
@@ -385,8 +385,9 @@ var/list/ob_type_fuel_requirements
 /obj/structure/ob_ammo/warhead/incendiary/warhead_impact(turf/target, inaccuracy_amt = 0)
 	var/range_num = max(8 - inaccuracy_amt*2, 3)
 	for(var/turf/TU in range(range_num,target))
-		if(!locate(/obj/flamer_fire) in TU)
-			new/obj/flamer_fire(TU, 10, 50) //super hot flames
+		for(var/obj/flamer_fire/F in TU) // No stacking flames!
+			cdel(F)
+		new/obj/flamer_fire(TU, 10, 50) //super hot flames
 
 
 /obj/structure/ob_ammo/warhead/cluster

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Boiler.dm
@@ -256,14 +256,15 @@
 	if(!istype(target) || istype(target,/turf/open/space))
 		return
 
-	if(!locate(/obj/effect/xenomorph/spray) in target) //No stacking flames!
-		new /obj/effect/xenomorph/spray(target)
-		for(var/mob/living/carbon/M in target)
-			if(ishuman(M) || ismonkey(M))
-				if((M.status_flags & XENO_HOST) && istype(M.buckled, /obj/structure/bed/nest))
-					continue //nested infected hosts are not hurt by acid spray
-				M.adjustFireLoss(rand(20 + 5 * upgrade, 30 + 5 * upgrade))
-				to_chat(M, "<span class='xenodanger'>\The [src] showers you in corrosive acid!</span>")
-				if(!isYautja(M))
-					M.emote("scream")
-					M.KnockDown(rand(3, 4))
+	for(var/obj/effect/xenomorph/spray/S in target) //No stacking spray!
+		cdel(S)
+	new /obj/effect/xenomorph/spray(target)
+	for(var/mob/living/carbon/M in target)
+		if(ishuman(M) || ismonkey(M))
+			if((M.status_flags & XENO_HOST) && istype(M.buckled, /obj/structure/bed/nest))
+				continue //nested infected hosts are not hurt by acid spray
+			M.adjustFireLoss(rand(20 + 5 * upgrade, 30 + 5 * upgrade))
+			to_chat(M, "<span class='xenodanger'>\The [src] showers you in corrosive acid!</span>")
+			if(!isYautja(M))
+				M.emote("scream")
+				M.KnockDown(rand(3, 4))

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Ravager.dm
@@ -149,10 +149,11 @@
 /mob/living/carbon/Xenomorph/Ravager/ravenger/proc/flame_turf(turf/T)
 	if(!istype(T))
 		return
-	if(!locate(/obj/flamer_fire) in T) // No stacking flames!
-		new/obj/flamer_fire(T)
-	else
-		return
+
+	for(var/obj/flamer_fire/F in T) // No stacking flames!
+		cdel(F)
+
+	new/obj/flamer_fire(T)
 
 	for(var/mob/living/carbon/M in T) //Deal bonus damage if someone's caught directly in initial stream
 		if(M.stat == DEAD)

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -184,8 +184,8 @@
 	proc/drop_flame(turf/T) // ~Art updated fire 20JAN17
 		if(!istype(T))
 			return
-		if(locate(/obj/flamer_fire) in T)
-			return
+		for(var/obj/flamer_fire/F in T) // No stacking flames!
+			cdel(F)
 		new /obj/flamer_fire(T, 20, 20)
 
 

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -872,10 +872,10 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	if(!istype(T))
 		return
 
-	if(!locate(/obj/flamer_fire) in T) // No stacking flames!
-		new/obj/flamer_fire(T)
-	else
-		return
+	for(var/obj/flamer_fire/F in T) // No stacking flames!
+		cdel(F)
+
+	new/obj/flamer_fire(T)
 
 	for(var/mob/living/carbon/M in T) //Deal bonus damage if someone's caught directly in initial stream
 		if(M.stat == DEAD)

--- a/code/modules/projectiles/updated_projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/flamer.dm
@@ -189,9 +189,8 @@
 	if(!istype(T))
 		return
 
-	// No stacking flames
-	if (locate(/obj/flamer_fire) in T)
-		return
+	for(var/obj/flamer_fire/F in T) // No stacking flames!
+		cdel(F)
 
 	new /obj/flamer_fire(T, heat, burn, f_color)
 

--- a/code/modules/reagents/chemistry_reactions/other.dm
+++ b/code/modules/reagents/chemistry_reactions/other.dm
@@ -216,7 +216,8 @@
 		for(var/turf/T in range(radius,location))
 			if(T.density) continue
 			if(istype(T,/turf/open/space)) continue
-			if(locate(/obj/flamer_fire) in T) continue //No stacking
+			for(var/obj/flamer_fire/F in T) // No stacking flames!
+				cdel(F)
 			new /obj/flamer_fire(T, 5 + rand(0,11))
 
 		holder.del_reagent("napalm")


### PR DESCRIPTION
...Instead of just doing nothing.
That means you can flame an already flamed turf to replinsh it. Won't stack as it deletes the previous flame.
But also means you can replace a turf's flame with another, be it weaker or stronger... as one would say: "Fight fire with fire".
Kind of also applies to boiler's spray.

Yet another downstream fix...