### PR TITLE
Permabans now only require +BAN

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -316,7 +316,8 @@
 		usr.client.warn(href_list["warn"])
 
 	else if(href_list["unbanupgradeperma"])
-		if(!check_rights(R_ADMIN)) return
+		if(!check_rights(R_BAN)) 
+			return
 		UpdateTime()
 		var/reason
 


### PR DESCRIPTION
This is a unneeded restriction and a holdover from CMs permaban requests.