### PR TITLE
More consistency and exploit patches for the autolathe.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -7,9 +7,7 @@
 	w_class = 2
 	flags_atom = FPRINT|CONDUCT
 	flags_equip_slot = SLOT_WAIST
-
 	matter = list("metal" = 50,"glass" = 20)
-
 	actions_types = list(/datum/action/item_action)
 	var/on = 0
 	var/brightness_on = 5 //luminosity when on
@@ -297,3 +295,4 @@
 	icon_state = "lantern"
 	desc = "A mining lantern."
 	brightness_on = 6			// luminosity when on
+	raillight_compatible = 0

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -9,9 +9,9 @@
 	flags_equip_slot = SLOT_WAIST
 	matter = list("metal" = 50,"glass" = 20)
 	actions_types = list(/datum/action/item_action)
-	var/on = 0
+	var/on = FALSE
 	var/brightness_on = 5 //luminosity when on
-	var/raillight_compatible = 1 //Can this be turned into a rail light ?
+	var/raillight_compatible = TRUE //Can this be turned into a rail light ?
 
 /obj/item/device/flashlight/initialize()
 	..()
@@ -145,7 +145,7 @@
 	flags_atom = FPRINT|CONDUCT
 	brightness_on = 2
 	w_class = 1
-	raillight_compatible = 0
+	raillight_compatible = FALSE
 
 /obj/item/device/flashlight/drone
 	name = "low-power flashlight"
@@ -154,7 +154,7 @@
 	item_state = ""
 	brightness_on = 2
 	w_class = 1
-	raillight_compatible = 0
+	raillight_compatible = FALSE
 
 //The desk lamps are a bit special
 /obj/item/device/flashlight/lamp
@@ -165,7 +165,7 @@
 	brightness_on = 5
 	w_class = 4
 	on = 1
-	raillight_compatible = 0
+	raillight_compatible = FALSE
 
 //Menorah!
 /obj/item/device/flashlight/lamp/menorah
@@ -175,7 +175,7 @@
 	item_state = "menorah"
 	brightness_on = 2
 	w_class = 4
-	on = 1
+	on = TRUE
 
 //Green-shaded desk lamp
 /obj/item/device/flashlight/lamp/green
@@ -206,7 +206,7 @@
 	icon_state = "flare"
 	item_state = "flare"
 	actions = list()	//just pull it manually, neckbeard.
-	raillight_compatible = 0
+	raillight_compatible = FALSE
 	var/fuel = 0
 	var/on_damage = 7
 
@@ -276,8 +276,8 @@
 	item_state = "slime"
 	w_class = 1
 	brightness_on = 6
-	on = 1 //Bio-luminesence has one setting, on.
-	raillight_compatible = 0
+	on = TRUE //Bio-luminesence has one setting, on.
+	raillight_compatible = FALSE
 
 /obj/item/device/flashlight/slime/New()
 	SetLuminosity(brightness_on)
@@ -295,4 +295,4 @@
 	icon_state = "lantern"
 	desc = "A mining lantern."
 	brightness_on = 6			// luminosity when on
-	raillight_compatible = 0
+	raillight_compatible = FALSE

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -77,6 +77,7 @@
 	desc = "The standard issue survival knife issued to Colonial Marines soldiers. You can slide this knife into your boots, and can be field-modified to attach to the end of a rifle."
 	flags_atom = FPRINT|CONDUCT
 	sharp = IS_SHARP_ITEM_ACCURATE
+	matter = list("metal" = 1000)
 	force = 25
 	w_class = 2
 	throwforce = 20

--- a/code/modules/cm_marines/equipment/gear.dm
+++ b/code/modules/cm_marines/equipment/gear.dm
@@ -5,10 +5,9 @@
 
 /obj/item/device/flashlight/combat
 	name = "combat flashlight"
-	desc = "A Flashlight designed to be held in the hand, or attached to a rifle"
-	icon_state = "flashlight"
-	item_state = "flashlight"
-	brightness_on = 5 //Pretty luminous, but still a flashlight that fits in a pocket
+	desc = "A robust flashlight designed to be held in the hand, or attached to a rifle"
+	force = 10 //This is otherwise no different from a normal flashlight minus the flavour.
+	throwforce = 12 //"combat" flashlight
 
 //MARINE SNIPER TARPS
 

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -275,6 +275,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	slot = "muzzle"
 	pixel_shift_x = 14 //Below the muzzle.
 	pixel_shift_y = 18
+	matter = list("metal" = 1000)
 
 /obj/item/attachable/bayonet/attackby(obj/item/I, mob/user)
 	if(istype(I,/obj/item/tool/screwdriver))
@@ -409,6 +410,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	attach_icon = "flashlight_a"
 	light_mod = 7
 	slot = "rail"
+	matter = list("metal" = 50,"glass" = 20)
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION
 	attachment_action_type = /datum/action/item_action/toggle
 
@@ -554,6 +556,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	desc = "A non-standard heavy wooden stock for the M37 Shotgun. Less quick and more cumbersome than the standard issue stakeout, but reduces recoil and improves accuracy. Allegedly makes a pretty good club in a fight too.."
 	slot = "stock"
 	wield_delay_mod = WIELD_DELAY_NORMAL
+	matter = null
 	icon_state = "stock"
 
 /obj/item/attachable/stock/shotgun/New()
@@ -570,6 +573,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/stock/tactical
 	name = "\improper MK221 tactical stock"
+	desc = "A sturdy polymer stock for the MK221 shotgun. Supplied in limited numbers and moderately encumbering, it provides an ergonomic surface to ease perceived recoil and usability."
 	icon_state = "tactical_stock"
 
 /obj/item/attachable/stock/tactical/New()
@@ -588,6 +592,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	icon_state = "slavicstock"
 	pixel_shift_x = 32
 	pixel_shift_y = 13
+	matter = null
 	flags_attach_features = NOFLAGS
 
 /obj/item/attachable/stock/slavic/New()
@@ -666,6 +671,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	icon_state = "44stock"
 	pixel_shift_x = 35
 	pixel_shift_y = 19
+	matter = null
 
 /obj/item/attachable/stock/revolver/New()
 	..()


### PR DESCRIPTION
After a general budget inspection, the uscm opted to replace faux wood metal stocks (that could have been decon'd in the autolathe for metal) with authentic ones.
The combat flashlight is a little more "combat" now.
Also it's no more possible to generate infinite metal with rail lights/flashlight conversions, nor you can convert lanterns.
Slight tweak with combat knife/bayonet matter amounts.