### PR TITLE
Barricade Bypass Update

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -47,6 +47,7 @@
 	var/bonus_projectiles_type 					// Type path of the extra projectiles
 	var/bonus_projectiles_amount 	= 0 		// How many extra projectiles it shoots out. Works kind of like firing on burst, but all of the projectiles travel together
 	var/debilitate[]				= null 		// Stun,knockdown,knockout,irradiate,stutter,eyeblur,drowsy,agony
+	var/barricade_clear_distance	= 1			// How far the bullet can travel before incurring a chance of hitting barricades; normally 1.
 
 	New()
 		accuracy 			= config.min_hit_accuracy 	// This is added to the bullet's base accuracy.
@@ -784,6 +785,7 @@
 	damage = config.med_hit_damage
 	penetration= config.mhigh_armor_penetration //Bumped the penetration to serve a different role from sentries, MGs are a bit more offensive
 	accuracy = config.med_hit_accuracy
+	barricade_clear_distance = 2
 
 /datum/ammo/bullet/minigun
 	name = "minigun bullet"

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -330,9 +330,7 @@
 	if(!( P.dir & reverse_direction(dir) || P.dir & dir))
 		return FALSE //no effect if bullet direction is perpendicular to barricade
 
-	var/distance = P.distance_travelled - 1
-
-	if(P.ammo.barricade_clear_distance > distance)
+	if(P.distance_travelled <= P.ammo.barricade_clear_distance)
 		return FALSE
 
 	var/coverage = 90 //maximum probability of blocking projectile

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -321,7 +321,7 @@
 	if(!throwpass)
 		return TRUE
 
-	if(P.ammo.flags_ammo_behavior & AMMO_SNIPER) //sniper rounds bypass cover
+	if(P.ammo.flags_ammo_behavior & AMMO_SNIPER || P.ammo.flags_ammo_behavior & AMMO_SKIPS_HUMANS) //sniper and IFF rounds bypass cover
 		return FALSE
 
 	if(!(flags_atom & ON_BORDER))
@@ -332,7 +332,7 @@
 
 	var/distance = P.distance_travelled - 1
 
-	if(distance < 1)
+	if(P.ammo.barricade_clear_distance > distance)
 		return FALSE
 
 	var/coverage = 90 //maximum probability of blocking projectile

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -321,7 +321,7 @@
 	if(!throwpass)
 		return TRUE
 
-	if(P.ammo.flags_ammo_behavior & AMMO_SNIPER || P.ammo.flags_ammo_behavior & AMMO_SKIPS_HUMANS) //sniper and IFF rounds bypass cover
+	if(P.ammo.flags_ammo_behavior & AMMO_SNIPER || P.ammo.flags_ammo_behavior & AMMO_SKIPS_HUMANS || P.ammo.flags_ammo_behavior & AMMO_ROCKET) //sniper, rockets and IFF rounds bypass cover
 		return FALSE
 
 	if(!(flags_atom & ON_BORDER))

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -330,8 +330,8 @@
 	if(!( P.dir & reverse_direction(dir) || P.dir & dir))
 		return FALSE //no effect if bullet direction is perpendicular to barricade
 		
-	var/distance = P.distance_travelled
-	if(distance <= P.ammo.barricade_clear_distance)
+	var/distance = P.distance_travelled - 1
+	if(distance < P.ammo.barricade_clear_distance)
 		return FALSE
 
 	var/coverage = 90 //maximum probability of blocking projectile

--- a/code/modules/projectiles/updated_projectiles/projectile.dm
+++ b/code/modules/projectiles/updated_projectiles/projectile.dm
@@ -329,8 +329,9 @@
 
 	if(!( P.dir & reverse_direction(dir) || P.dir & dir))
 		return FALSE //no effect if bullet direction is perpendicular to barricade
-
-	if(P.distance_travelled <= P.ammo.barricade_clear_distance)
+		
+	var/distance = P.distance_travelled
+	if(distance <= P.ammo.barricade_clear_distance)
 		return FALSE
 
 	var/coverage = 90 //maximum probability of blocking projectile


### PR DESCRIPTION
-IFF bullets now have no barricade block chance.

-M56D bullets can travel up to two tiles before having a barricade block chance, slightly improving their range of viable placement.