### PR TITLE
Xenos Can't Drag Corpses

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -43,10 +43,6 @@
 	if(!gibbed)
 		src.visible_message("<b>\The [src.name]</b> [deathmessage]")
 
-	if(pulledby)
-		if(isXeno(pulledby)) //Xenos drop dead guys
-			pulledby.stop_pulling()
-
 	stat = DEAD
 
 	update_canmove()

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -43,6 +43,10 @@
 	if(!gibbed)
 		src.visible_message("<b>\The [src.name]</b> [deathmessage]")
 
+	if(pulledby)
+		if(isXeno(pulledby)) //Xenos drop dead guys
+			pulledby.stop_pulling()
+
 	stat = DEAD
 
 	update_canmove()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -52,7 +52,6 @@
 /mob/living/carbon/human/death(gibbed)
 
 	if(stat == DEAD) return
-	if(!gibbed) disable_lights()
 	if(pulledby)
 		pulledby.stop_pulling()
 	//Handle species-specific deaths.

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -450,9 +450,6 @@
 					drop_inv_item_on_ground(I)
 					if(I && !I.disposed) //Might be self-deleted?
 						M.equip_to_slot_if_possible(I, slot_to_process, 1, 0, 1, 1)
-						if(ishuman(M) && M.stat == DEAD)
-							var/mob/living/carbon/human/H = M
-							H.disable_lights() // take that powergamers -spookydonut
 
 	if(M)
 		if(interactee == M && Adjacent(M))

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -300,7 +300,6 @@
 			var/mob/living/carbon/human/H
 			if(ishuman(target))
 				H = target
-				H.disable_lights()
 				playsound(loc, (target.gender == "male"?'sound/misc/facehugged_male.ogg' : 'sound/misc/facehugged_female.ogg') , 25, 0)
 			if(!sterile)
 				if(!H || !H.species || !(H.species.flags & IS_SYNTHETIC)) //synthetics aren't paralyzed

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -200,11 +200,14 @@
 	var/mob/living/L = AM
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.
-	if(ishuman(L) && L.stat == DEAD)
+	/*if(ishuman(L) && L.stat == DEAD)
 		var/mob/living/carbon/human/H = L
-		if(H.undefibbable)
-			to_chat(src, "<span class='xenowarning'>Not alive, not interesting. Maybe when it has gone colder.</span>")
-			return FALSE // leave the defibbable dead alone
+		if(H.status_flags & XENO_HOST)
+			if(world.time > H.timeofdeath + H.revive_grace_period)
+				return FALSE // they ain't gonna burst now
+		else
+			return FALSE // leave the dead alone*
+	*/ // this is disabled pending the results of the lighting change -spookydonut
 	return ..()
 
 /mob/living/carbon/Xenomorph/pull_response(mob/puller)

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -198,18 +198,13 @@
 	if(!isliving(AM))
 		return FALSE
 	var/mob/living/L = AM
-	if(isSynth(L) && L.stat == DEAD) //no meta hiding synthetic bodies
-		return FALSE
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.
-	/*if(ishuman(L) && L.stat == DEAD)
+	if(ishuman(L) && L.stat == DEAD)
 		var/mob/living/carbon/human/H = L
-		if(H.status_flags & XENO_HOST)
-			if(world.time > H.timeofdeath + H.revive_grace_period)
-				return FALSE // they ain't gonna burst now
-		else
-			return FALSE // leave the dead alone*
-	*/ // this is disabled pending the results of the lighting change -spookydonut
+		if(H.undefibbable)
+			to_chat(src, "<span class='xenowarning'>Not alive, not interesting. Maybe when it has gone colder.</span>")
+			return FALSE // leave the defibbable dead alone
 	return ..()
 
 /mob/living/carbon/Xenomorph/pull_response(mob/puller)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -30,7 +30,12 @@
 				return 0
 
 			if(Adjacent(M)) //Logic!
-				M.start_pulling(src)
+				if(stat == DEAD)
+					if(is_revivable())
+						to_chat(src, "<span class='warning'>The creature is dead, why would you want to touch it?</span>")
+						return
+				else
+					M.start_pulling(src)
 
 		if("hurt")
 			var/datum/hive_status/hive

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -43,7 +43,18 @@
 				return FALSE
 
 			if(stat == DEAD)
-				to_chat(M, "<span class='warning'>[src] is dead, why would you want to touch it?</span>")
+				if(luminosity > 0)
+					playsound(loc, "alien_claw_metal", 25, 1)
+					M.flick_attack_overlay(src, "slash")
+					var/datum/effect_system/spark_spread/spark_system2
+					spark_system2 = new /datum/effect_system/spark_spread()
+					spark_system2.set_up(5, 0, src)
+					spark_system2.attach(src)
+					spark_system2.start(src)
+					disable_lights()
+					to_chat(M, "<span class='warning'>You disable whatever annoying lights the dead creature possesses.</span>")
+				else
+					to_chat(M, "<span class='warning'>[src] is dead, why would you want to touch it?</span>")
 				return FALSE
 
 			if(!M.is_intelligent)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -30,12 +30,7 @@
 				return 0
 
 			if(Adjacent(M)) //Logic!
-				if(stat == DEAD)
-					if(is_revivable())
-						to_chat(src, "<span class='warning'>The creature is dead, why would you want to touch it?</span>")
-						return
-				else
-					M.start_pulling(src)
+				M.start_pulling(src)
 
 		if("hurt")
 			var/datum/hive_status/hive

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -369,12 +369,6 @@ var/list/slot_equipment_priority = list( \
 	var/mob/M
 	if(ismob(AM))
 		M = AM
-		if(isXeno(src) && M.stat == DEAD)
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				if(H.is_revivable())
-					to_chat(src, "<span class='warning'>The creature is dead, why would you want to touch it?</span>")
-					return
 
 	else if(istype(AM, /obj))
 		AM.add_fingerprint(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -370,8 +370,11 @@ var/list/slot_equipment_priority = list( \
 	if(ismob(AM))
 		M = AM
 		if(isXeno(src) && M.stat == DEAD)
-			to_chat(src, "<span class='warning'>The creature is dead, why would you want to touch it?</span>")
-			return
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(H.is_revivable())
+					to_chat(src, "<span class='warning'>The creature is dead, why would you want to touch it?</span>")
+					return
 
 	else if(istype(AM, /obj))
 		AM.add_fingerprint(src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -369,6 +369,10 @@ var/list/slot_equipment_priority = list( \
 	var/mob/M
 	if(ismob(AM))
 		M = AM
+		if(isXeno(src) && M.stat == DEAD)
+			to_chat(src, "<span class='warning'>The creature is dead, why would you want to touch it?</span>")
+			return
+
 	else if(istype(AM, /obj))
 		AM.add_fingerprint(src)
 


### PR DESCRIPTION
-Prevents xenos from dragging corpses.

-Xenos auto-drop mobs that die.

-Xenos can 'attack' corpses with lights to disable those lights.