### PR TITLE
SMG Fix

### DIFF
--- a/code/modules/projectiles/updated_projectiles/guns/smgs.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/smgs.dm
@@ -60,8 +60,8 @@
 
 /obj/item/weapon/gun/smg/m39/set_gun_config_values()
 	fire_delay = config.low_fire_delay
-	burst_delay = config.mlow_fire_delay
-	burst_amount = config.high_burst_value
+	burst_delay = config.min_fire_delay
+	burst_amount = config.med_burst_value
 	accuracy_mult = config.base_hit_accuracy_mult
 	accuracy_mult_unwielded = config.base_hit_accuracy_mult - config.hmed_hit_accuracy_mult
 	scatter = config.med_scatter_value


### PR DESCRIPTION
-Decreased burst amount by 1.
-Halved delay between burst shots.

Should make the SMG effective as a personal defense weapon at close-close medium range.