### PR TITLE
Set Respawn Timer admin verb.

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1,6 +1,6 @@
-
 var/global/BSACooldown = 0
 var/global/floorIsLava = 0
+var/global/respawntime = 15
 
 
 ////////////////////////////////
@@ -848,6 +848,17 @@ var/global/floorIsLava = 0
 	log_admin("[key_name(usr)] toggled respawn to [abandon_allowed ? "On" : "Off"].")
 	world.update_status()
 	feedback_add_details("admin_verb","TR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/datum/admins/proc/toggleatime()
+	set category = "Server"
+	set desc="Sets the respawn time"
+	set name="Set Respawn Timer"
+	var/message = input("Enter time in minutes:") as message
+	respawntime = text2num(message)
+	message_admins("\blue [key_name_admin(usr)] set the respawn time to [respawntime].", 1)
+	log_admin("[key_name(usr)] set the respawn time to [respawntime].")
+	world.update_status()
+	feedback_add_details("admin_verb","TRT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/end_round()
 	set category = "Server"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -849,14 +849,13 @@ var/global/respawntime = 15
 	world.update_status()
 	feedback_add_details("admin_verb","TR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/datum/admins/proc/toggleatime()
+/datum/admins/proc/toggleatime(time as num)
 	set category = "Server"
 	set desc="Sets the respawn time"
 	set name="Set Respawn Timer"
-	var/message = input("Enter time in minutes:") as message
-	respawntime = text2num(message)
-	message_admins("\blue [key_name_admin(usr)] set the respawn time to [respawntime].", 1)
-	log_admin("[key_name(usr)] set the respawn time to [respawntime].")
+	respawntime = time
+	message_admins("\blue [key_name_admin(usr)] set the respawn time to [respawntime] minutes.", 1)
+	log_admin("[key_name(usr)] set the respawn time to [respawntime] minutes.")
 	world.update_status()
 	feedback_add_details("admin_verb","TRT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -853,7 +853,10 @@ var/global/respawntime = 15
 	set category = "Server"
 	set desc="Sets the respawn time"
 	set name="Set Respawn Timer"
-	respawntime = time
+	if (time > 0)
+		respawntime = time
+	else
+		to_chat(usr, "The respawn time must be larger than 0!")
 	message_admins("\blue [key_name_admin(usr)] set the respawn time to [respawntime] minutes.", 1)
 	log_admin("[key_name(usr)] set the respawn time to [respawntime] minutes.")
 	world.update_status()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -853,10 +853,10 @@ var/global/respawntime = 15
 	set category = "Server"
 	set desc="Sets the respawn time"
 	set name="Set Respawn Timer"
-	if (time > 0)
+	if (time >= 0)
 		respawntime = time
 	else
-		to_chat(usr, "The respawn time must be larger than 0!")
+		to_chat(usr, "The respawn time cannot be a negative number!")
 	message_admins("\blue [key_name_admin(usr)] set the respawn time to [respawntime] minutes.", 1)
 	log_admin("[key_name(usr)] set the respawn time to [respawntime] minutes.")
 	world.update_status()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -113,6 +113,7 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/restart,
 	/datum/admins/proc/delay,
 	/datum/admins/proc/toggleaban,
+	/datum/admins/proc/toggleatime,
 	/datum/admins/proc/end_round,
 	/client/proc/toggle_log_hrefs,
 	/datum/admins/proc/toggleAI,

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -1,5 +1,3 @@
-
-
 /mob/verb/mode()
 	set name = "Activate Held Object"
 	set category = "Object"
@@ -113,8 +111,8 @@
 		var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 		to_chat(usr, "You have been dead for[pluralcheck] [deathtimeseconds] seconds.")
 
-		if (deathtime < 9000 && !is_admin)
-			to_chat(usr, "You must wait 15 minutes to respawn!")
+		if (deathtime < (respawntime * 600) && !is_admin)
+			to_chat(usr, "You must wait [respawntime] minutes to respawn!")
 			return
 		else
 			to_chat(usr, "You can respawn now, enjoy your new life!")

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -113,8 +113,8 @@
 		var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 		to_chat(usr, "You have been dead for[pluralcheck] [deathtimeseconds] seconds.")
 
-		if (deathtime < 18000 && !is_admin)
-			to_chat(usr, "You must wait 30 minutes to respawn!")
+		if (deathtime < 9000 && !is_admin)
+			to_chat(usr, "You must wait 15 minutes to respawn!")
 			return
 		else
 			to_chat(usr, "You can respawn now, enjoy your new life!")


### PR DESCRIPTION
Temporary lowpop bandaid until we get a better solution. It's still an admin-only verb that starts disabled so it shouldn't cause any issues at the moment.