### PR TITLE
Minor number correction for ancient carrier description

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoUpgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoUpgrade.dm
@@ -660,7 +660,7 @@ Queen		 0.0	 0.1	 0.2	 0.3
 					maxHealth = 250
 					plasma_max = 400
 					plasma_gain = 15
-					caste_desc = "It's literally crawling with 10 huggers."
+					caste_desc = "It's literally crawling with 11 huggers."
 					armor_deflection = 15
 					tacklemin = 5
 					tacklemax = 6


### PR DESCRIPTION
I don't know if "blah [CA.huggers_max] blah" would work since I don't know how references are stored in strings and I'm not prepared to set up a test host to find out for a one digit change.