### PR TITLE
Makes ap rockets actualy do direct hit damage

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -848,38 +848,49 @@
 	smoke.set_up(1, get_turf(P))
 	smoke.start()
 
-/datum/ammo/rocket/ap
+/datum/ammo/rocketap
 	name = "anti-armor rocket"
 	damage_falloff = 0
+	ping = null //no bounce off.
+	sound_bounce	= "rocket_bounce"
+	flags_ammo_behavior = AMMO_EXPLOSIVE|AMMO_ROCKET
+	var/datum/effect_system/smoke_spread/smoke
 
-/datum/ammo/rocket/ap/New()
+
+/datum/ammo/rocketap/New()
 	..()
+	smoke = new()
 	accuracy = -config.min_hit_accuracy
 	accuracy_var_low = config.med_proj_variance
 	accurate_range = config.short_shell_range
 	max_range = config.norm_shell_range
 	damage = config.ultra_hit_damage //lmao tons of hit damage but it's never processed due to the below proc redefinitions
 	penetration= config.max_armor_penetration
+	shell_speed = config.slow_shell_speed
 
-/datum/ammo/rocket/ap/on_hit_mob(mob/M, obj/item/projectile/P)
+/datum/ammo/rocketap/on_hit_mob(mob/M, obj/item/projectile/P)
 	explosion(get_turf(M), -1, 1, 2, 5)
 	smoke.set_up(1, get_turf(M))
 	smoke.start()
+	..()
 
-/datum/ammo/rocket/ap/on_hit_obj(obj/O, obj/item/projectile/P)
+/datum/ammo/rocketap/on_hit_obj(obj/O, obj/item/projectile/P)
 	explosion(get_turf(O), -1, 1, 2, 5)
 	smoke.set_up(1, get_turf(O))
 	smoke.start()
+	..()
 
-/datum/ammo/rocket/ap/on_hit_turf(turf/T, obj/item/projectile/P)
+/datum/ammo/rocketap/on_hit_turf(turf/T, obj/item/projectile/P)
 	explosion(T,  -1, 1, 2, 5)
 	smoke.set_up(1, T)
 	smoke.start()
+	..()
 
-/datum/ammo/rocket/ap/do_at_max_range(obj/item/projectile/P)
+/datum/ammo/rocketap/do_at_max_range(obj/item/projectile/P)
 	explosion(get_turf(P),  -1, 1, 2, 5)
 	smoke.set_up(1, get_turf(P))
 	smoke.start()
+	..()
 
 /datum/ammo/rocket/ltb
 	name = "cannon round"

--- a/code/modules/projectiles/updated_projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/magazines/specialist.dm
@@ -130,7 +130,7 @@
 /obj/item/ammo_magazine/rocket/ap
 	name = "\improper 84mm anti-armor rocket"
 	icon_state = "ap_rocket"
-	default_ammo = /datum/ammo/rocket/ap
+	default_ammo = /datum/ammo/rocketap
 	desc = "A tube for an AP rocket, the warhead of which is extremely dense and turns molten on impact. When empty, use this frame to deconstruct it."
 
 /obj/item/ammo_magazine/rocket/wp

--- a/code/modules/vehicles/hardpoints.dm
+++ b/code/modules/vehicles/hardpoints.dm
@@ -821,7 +821,7 @@ Currently only has the tank hardpoints
 	caliber = "rocket" //correlates to any rocket mags
 	icon_state = "quad_rocket"
 	w_class = 10
-	default_ammo = /datum/ammo/rocket/ap //Fun fact, AP rockets seem to be a straight downgrade from normal rockets. Maybe I'm missing something...
+	default_ammo = /datum/ammo/rocketap //Fun fact, AP rockets seem to be a straight downgrade from normal rockets. Maybe I'm missing something...
 	max_rounds = 5
 	point_cost = 100
 	gun_type = /obj/item/hardpoint/secondary/towlauncher


### PR DESCRIPTION
Say it with me: Don't make sub-types that override all the parents unique behaviors.  Especially if that parent overrode something you needed.
🆑
fix: AP rockets actually do impact damage.
/:cl:

Fixes some high quality cm code, that was clearly labeled but never actually fixed by anyone.
This probably makes ap rockets too good.