### PR TITLE
Synth Fix

### DIFF
--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -29,6 +29,12 @@
 			to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 			return
 
+		if(ishuman(user))
+			var/mob/living/carbon/human/S = user
+			if(S.species.flags & IS_SYNTHETIC)
+				to_chat(user, "<span class='warning'>Your programming prevents you from operating this device!</span>")
+				return
+
 		add_fingerprint(user)
 		activate(user)
 		if((CLUMSY in user.mutations) && prob(50))

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -70,7 +70,7 @@
 		icon_state = "telebaton_1"
 		item_state = "telebaton_1"
 		w_class = 3
-		force = 40//Super Robust - Probably shouldn't give it to anyone who isn't staff unless you want BEATINGS
+		force = 10//Super Robust - Probably shouldn't give it to anyone who isn't staff unless you want BEATINGS
 		attack_verb = list("smacked", "struck", "slapped")
 	else
 		user.visible_message("\blue [user] collapses their telescopic baton.",\

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -70,7 +70,7 @@
 		icon_state = "telebaton_1"
 		item_state = "telebaton_1"
 		w_class = 3
-		force = 50//Super Robust - Probably shouldn't give it to anyone who isn't staff unless you want BEATINGS
+		force = 40//Super Robust - Probably shouldn't give it to anyone who isn't staff unless you want BEATINGS
 		attack_verb = list("smacked", "struck", "slapped")
 	else
 		user.visible_message("\blue [user] collapses their telescopic baton.",\
@@ -109,9 +109,10 @@
 			user.KnockDown(3 * force)
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
-				H.apply_damage(2*force, BRUTE, "head")
+				H.apply_damage(force, BRUTE, "head")
+				H.apply_damage(force, HALLOSS, "head")
 			else
-				user.take_limb_damage(2*force)
+				user.take_limb_damage(force * 2)
 			return
 		if(..())
 			//playsound(src.loc, "swing_hit", 25, 1, 6)

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -70,7 +70,7 @@
 		icon_state = "telebaton_1"
 		item_state = "telebaton_1"
 		w_class = 3
-		force = 10//Super Robust - Probably shouldn't give it to anyone who isn't staff unless you want BEATINGS
+		force = 10
 		attack_verb = list("smacked", "struck", "slapped")
 	else
 		user.visible_message("\blue [user] collapses their telescopic baton.",\


### PR DESCRIPTION
-Synths can no longer directly activate grenades as it's against their programming.

-Telescopic baton damage reduced to at least semi-reasonable levels.