### PR TITLE
Minor Attachments Rebalance

### DIFF
--- a/code/controllers/settings/combat_defines.dm
+++ b/code/controllers/settings/combat_defines.dm
@@ -52,7 +52,7 @@
 	var/max_hit_damage_mult = 0.35
 
 	var/reg_damage_falloff = 1
-	var/smg_damage_falloff = 2
+	var/smg_damage_falloff = 1.5
 	var/buckshot_damage_falloff = 5
 	var/extra_damage_falloff = 10
 
@@ -130,6 +130,18 @@
 	var/med_proj_variance = 3
 	var/high_proj_variance = 4
 	var/max_proj_variance = 5
+
+	var/min_movement_acc_penalty = 1
+	var/low_movement_acc_penalty = 2
+	var/med_movement_acc_penalty = 3
+	var/high_movement_acc_penalty = 4
+	var/max_movement_acc_penalty = 5
+
+	var/min_burst_scatter_penalty = 1
+	var/low_burst_scatter_penalty = 2
+	var/med_burst_scatter_penalty = 3
+	var/high_burst_scatter_penalty = 4
+	var/max_burst_scatter_penalty = 5
 
 /datum/configuration/proc/initialize_combat_defines(name,value)
 	value = text2num(value)

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -975,24 +975,22 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/gyro
 	name = "gyroscopic stabilizer"
-	desc = "A set of weights and balances to stabilize the weapon when fired with one hand, reducing burst scatter and movement penalties to accuracy. Slightly decrease firing speed."
+	desc = "A set of weights and balances to stabilize the weapon when shooting one-handed, burst firing or moving. Significantly reduces burst scatter, movement penalties and one-handed recoil and scatter."
 	icon_state = "gyro"
 	attach_icon = "gyro_a"
 	slot = "under"
 
 /obj/item/attachable/gyro/New()
 	..()
-	delay_mod = config.low_fire_delay
-	scatter_mod = -config.min_scatter_value
 	burst_scatter_mod = -2
 	movement_acc_penalty_mod = -3
-	scatter_unwielded_mod = -config.med_scatter_value
-	accuracy_unwielded_mod = config.low_hit_accuracy_mult
-
-
+	scatter_unwielded_mod = -config.low_scatter_value
+	accuracy_unwielded_mod = config.min_hit_accuracy_mult
+	recoil_unwielded_mod = -config.low_recoil_value
+	
 /obj/item/attachable/lasersight
 	name = "laser sight"
-	desc = "A laser sight placed under the barrel. Increases accuracy, and decrease scatter when firing one-handed."
+	desc = "A laser sight placed under the barrel. Significantly increases accuracy while moving, whether wielding or one-handed."
 	icon_state = "lasersight"
 	attach_icon = "lasersight_a"
 	slot = "under"
@@ -1001,9 +999,8 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/lasersight/New()
 	..()
-	accuracy_mod = config.min_hit_accuracy_mult
-	movement_acc_penalty_mod = -1
-	scatter_unwielded_mod = -config.low_scatter_value
+	accuracy_mod = config.med_hit_accuracy_mult
+	movement_acc_penalty_mod = -2
 	accuracy_unwielded_mod = config.med_hit_accuracy_mult
 
 

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -333,7 +333,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/compensator
 	name = "recoil compensator"
-	desc = "A muzzle attachment that reduces recoil by diverting expelled gasses upwards. \nIncreases accuracy and reduces recoil, at the cost of a small amount of weapon damage."
+	desc = "A muzzle attachment that reduces recoil and scatter by diverting expelled gasses upwards. \nSignificantly reduces recoil and scatter, at the cost of a small amount of weapon damage."
 	slot = "muzzle"
 	icon_state = "comp"
 	attach_icon = "comp_a"
@@ -341,11 +341,11 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/compensator/New()
 	..()
-	accuracy_mod = config.med_hit_accuracy_mult
+	scatter_mod = -config.med_scatter_value
 	damage_mod = -config.min_hit_damage_mult
 	recoil_mod = -config.med_recoil_value
-	accuracy_unwielded_mod = config.med_hit_accuracy_mult
-	recoil_unwielded_mod = -config.low_recoil_value
+	scatter_unwielded_mod = -config.med_scatter_value
+	recoil_unwielded_mod = -config.med_recoil_value
 
 
 /obj/item/attachable/slavicbarrel
@@ -555,19 +555,16 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	name = "\improper M37 wooden stock"
 	desc = "A non-standard heavy wooden stock for the M37 Shotgun. Less quick and more cumbersome than the standard issue stakeout, but reduces recoil and improves accuracy. Allegedly makes a pretty good club in a fight too.."
 	slot = "stock"
-	wield_delay_mod = WIELD_DELAY_NORMAL
+	wield_delay_mod = WIELD_DELAY_FAST
 	matter = null
 	icon_state = "stock"
 
 /obj/item/attachable/stock/shotgun/New()
 	..()
-	accuracy_mod = config.min_hit_accuracy_mult
-	recoil_mod = -config.min_recoil_value
-	scatter_mod = -config.min_scatter_value
-	movement_acc_penalty_mod = -1
-	accuracy_unwielded_mod = config.min_hit_accuracy_mult
-	recoil_unwielded_mod = -config.min_recoil_value
-	scatter_unwielded_mod = -config.min_scatter_value
+	accuracy_mod = config.low_hit_accuracy_mult
+	recoil_mod = -config.med_recoil_value
+	scatter_mod = -config.med_scatter_value
+	movement_acc_penalty_mod = 1
 
 	select_gamemode_skin(type)
 
@@ -579,17 +576,15 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 /obj/item/attachable/stock/tactical/New()
 	..()
 	accuracy_mod = config.min_hit_accuracy_mult
-	recoil_mod = -config.min_recoil_value
-	scatter_mod = -config.min_scatter_value
-	movement_acc_penalty_mod = -1
-	accuracy_unwielded_mod = config.min_hit_accuracy_mult
-	recoil_unwielded_mod = -config.min_recoil_value
-	scatter_unwielded_mod = -config.min_scatter_value
+	recoil_mod = -config.med_recoil_value
+	scatter_mod = -config.med_scatter_value
+	movement_acc_penalty_mod = 1
 
 /obj/item/attachable/stock/slavic
 	name = "wooden stock"
 	desc = "A non-standard heavy wooden stock for Slavic firearms."
 	icon_state = "slavicstock"
+	wield_delay_mod = WIELD_DELAY_NORMAL
 	pixel_shift_x = 32
 	pixel_shift_y = 13
 	matter = null
@@ -598,14 +593,9 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 /obj/item/attachable/stock/slavic/New()
 	..()
 	accuracy_mod = config.min_hit_accuracy_mult
-	recoil_mod = -config.min_recoil_value
-	scatter_mod = -config.min_scatter_value
-	delay_mod = config.med_fire_delay
-	movement_acc_penalty_mod = -1
-	accuracy_unwielded_mod = config.min_hit_accuracy_mult
-	recoil_unwielded_mod = -config.min_recoil_value
-	scatter_unwielded_mod = -config.min_scatter_value
-
+	recoil_mod = -config.med_recoil_value
+	scatter_mod = -config.med_scatter_value
+	movement_acc_penalty_mod = 1
 
 /obj/item/attachable/stock/rifle
 	name = "\improper M41A skeleton stock"
@@ -621,14 +611,10 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/stock/rifle/New()
 	..()
-	accuracy_mod = config.low_hit_accuracy_mult
-	recoil_mod = -config.min_recoil_value
-	scatter_mod = -config.min_scatter_value
-	movement_acc_penalty_mod = -1
-	accuracy_unwielded_mod = config.min_hit_accuracy_mult
-	recoil_unwielded_mod = -config.min_recoil_value
-	scatter_unwielded_mod = -config.min_scatter_value
-
+	accuracy_mod = config.min_hit_accuracy_mult
+	recoil_mod = -config.med_recoil_value
+	scatter_mod = -config.med_scatter_value
+	movement_acc_penalty_mod = 1
 
 /obj/item/attachable/stock/rifle/marksman
 	name = "\improper M41A marksman stock"
@@ -651,21 +637,17 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/stock/smg/New()
 	..()
-	accuracy_mod = config.min_hit_accuracy_mult
-	recoil_mod = -config.min_recoil_value
-	scatter_mod = -config.min_scatter_value
-	movement_acc_penalty_mod = -1
-	accuracy_unwielded_mod = config.min_hit_accuracy_mult
-	recoil_unwielded_mod = -config.min_recoil_value
-	scatter_unwielded_mod = -config.low_scatter_value
-
+	accuracy_mod = config.low_hit_accuracy_mult
+	recoil_mod = -config.med_recoil_value
+	scatter_mod = -config.med_scatter_value
+	movement_acc_penalty_mod = 1
 
 
 /obj/item/attachable/stock/revolver
 	name = "\improper M44 magnum sharpshooter stock"
 	desc = "A wooden stock modified for use on a 44-magnum. Increases accuracy and reduces recoil at the expense of handling and agility. Less effective in melee as well"
 	slot = "stock"
-	wield_delay_mod = WIELD_DELAY_FAST
+	wield_delay_mod = WIELD_DELAY_VERY_FAST
 	melee_mod = -5
 	size_mod = 2
 	icon_state = "44stock"
@@ -675,16 +657,13 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/stock/revolver/New()
 	..()
-	accuracy_mod = config.med_hit_accuracy_mult
-	recoil_mod = -config.min_recoil_value
-	scatter_mod = -config.min_scatter_value
+	accuracy_mod = config.low_hit_accuracy_mult
+	recoil_mod = -config.med_recoil_value
+	scatter_mod = -config.med_scatter_value
 
 	accuracy_unwielded_mod = config.min_hit_accuracy_mult
 	recoil_unwielded_mod = -config.min_recoil_value
 	scatter_unwielded_mod = -config.min_scatter_value
-
-
-
 
 
 ////////////// Underbarrel Attachments ////////////////////////////////////
@@ -996,14 +975,14 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/gyro
 	name = "gyroscopic stabilizer"
-	desc = "A set of weights and balances to stabilize the weapon when fired with one hand. Slightly decrease firing speed."
+	desc = "A set of weights and balances to stabilize the weapon when fired with one hand, reducing burst scatter and movement penalties to accuracy. Slightly decrease firing speed."
 	icon_state = "gyro"
 	attach_icon = "gyro_a"
 	slot = "under"
 
 /obj/item/attachable/gyro/New()
 	..()
-	delay_mod = config.mlow_fire_delay
+	delay_mod = config.low_fire_delay
 	scatter_mod = -config.min_scatter_value
 	burst_scatter_mod = -2
 	movement_acc_penalty_mod = -3

--- a/code/modules/projectiles/updated_projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_attachables.dm
@@ -400,7 +400,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	..()
 	accuracy_mod = config.med_hit_accuracy_mult
 	accuracy_unwielded_mod = config.min_hit_accuracy_mult
-	movement_acc_penalty_mod = 1
+	movement_acc_penalty_mod = -config.min_movement_acc_penalty
 
 
 /obj/item/attachable/flashlight
@@ -498,7 +498,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	..()
 	burst_delay_mod = config.mhigh_fire_delay
 	accuracy_mod = config.high_hit_accuracy_mult
-	movement_acc_penalty_mod = 2
+	movement_acc_penalty_mod = config.low_movement_acc_penalty
 	accuracy_unwielded_mod = -config.min_hit_accuracy_mult
 
 
@@ -564,7 +564,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	accuracy_mod = config.low_hit_accuracy_mult
 	recoil_mod = -config.med_recoil_value
 	scatter_mod = -config.med_scatter_value
-	movement_acc_penalty_mod = 1
+	movement_acc_penalty_mod = config.min_movement_acc_penalty
 
 	select_gamemode_skin(type)
 
@@ -578,7 +578,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	accuracy_mod = config.min_hit_accuracy_mult
 	recoil_mod = -config.med_recoil_value
 	scatter_mod = -config.med_scatter_value
-	movement_acc_penalty_mod = 1
+	movement_acc_penalty_mod = config.min_movement_acc_penalty
 
 /obj/item/attachable/stock/slavic
 	name = "wooden stock"
@@ -595,7 +595,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	accuracy_mod = config.min_hit_accuracy_mult
 	recoil_mod = -config.med_recoil_value
 	scatter_mod = -config.med_scatter_value
-	movement_acc_penalty_mod = 1
+	movement_acc_penalty_mod = config.min_movement_acc_penalty
 
 /obj/item/attachable/stock/rifle
 	name = "\improper M41A skeleton stock"
@@ -614,7 +614,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	accuracy_mod = config.min_hit_accuracy_mult
 	recoil_mod = -config.med_recoil_value
 	scatter_mod = -config.med_scatter_value
-	movement_acc_penalty_mod = 1
+	movement_acc_penalty_mod = config.min_movement_acc_penalty
 
 /obj/item/attachable/stock/rifle/marksman
 	name = "\improper M41A marksman stock"
@@ -640,7 +640,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	accuracy_mod = config.low_hit_accuracy_mult
 	recoil_mod = -config.med_recoil_value
 	scatter_mod = -config.med_scatter_value
-	movement_acc_penalty_mod = 1
+	movement_acc_penalty_mod = config.min_movement_acc_penalty
 
 
 /obj/item/attachable/stock/revolver
@@ -660,6 +660,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	accuracy_mod = config.low_hit_accuracy_mult
 	recoil_mod = -config.med_recoil_value
 	scatter_mod = -config.med_scatter_value
+	movement_acc_penalty_mod = config.min_movement_acc_penalty
 
 	accuracy_unwielded_mod = config.min_hit_accuracy_mult
 	recoil_unwielded_mod = -config.min_recoil_value
@@ -934,7 +935,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/verticalgrip
 	name = "vertical grip"
-	desc = "A custom-built improved foregrip for better accuracy, less recoil, and less scatter, especially during burst fire. \nHowever, it also increases weapon size."
+	desc = "A custom-built improved foregrip for better accuracy, less recoil, and less scatter when wielded especially during burst fire. \nHowever, it also increases weapon size, slightly increases wield delay and makes unwielded fire more cumbersome."
 	icon_state = "verticalgrip"
 	attach_icon = "verticalgrip_a"
 	wield_delay_mod = WIELD_DELAY_FAST
@@ -945,17 +946,17 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 /obj/item/attachable/verticalgrip/New()
 	..()
 	accuracy_mod = config.min_hit_accuracy_mult
-	recoil_mod = -config.min_recoil_value
+	recoil_mod = -config.low_recoil_value
 	scatter_mod = -config.min_scatter_value
-	burst_scatter_mod = -2
-	movement_acc_penalty_mod = 1
+	burst_scatter_mod = -config.low_burst_scatter_penalty
+	movement_acc_penalty_mod = config.min_movement_acc_penalty
 	accuracy_unwielded_mod = -config.min_hit_accuracy_mult
 	scatter_unwielded_mod = config.min_scatter_value
 
 
 /obj/item/attachable/angledgrip
 	name = "angled grip"
-	desc = "A custom-built improved foregrip for less recoil, and faster wielding time. \nHowever, it also increases weapon size."
+	desc = "A custom-built improved foregrip for less recoil, and faster wielding time. \nHowever, it also increases weapon size, and slightly hinders unwielded firing."
 	icon_state = "angledgrip"
 	attach_icon = "angledgrip_a"
 	wield_delay_mod = -WIELD_DELAY_FAST
@@ -967,30 +968,30 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 	..()
 	recoil_mod = -config.min_recoil_value
 	accuracy_mod = config.min_hit_accuracy_mult
-	accuracy_unwielded_mod = -config.min_hit_accuracy_mult
 	scatter_mod = -config.min_scatter_value
+	accuracy_unwielded_mod = -config.min_hit_accuracy_mult
 	scatter_unwielded_mod = config.min_scatter_value
 
 
 
 /obj/item/attachable/gyro
 	name = "gyroscopic stabilizer"
-	desc = "A set of weights and balances to stabilize the weapon when shooting one-handed, burst firing or moving. Significantly reduces burst scatter, movement penalties and one-handed recoil and scatter."
+	desc = "A set of weights and balances to stabilize the weapon when shooting one-handed, burst firing or moving. Greatly reduces movement penalties to accuracy. Significantly reduces burst scatter, and one-handed recoil and scatter."
 	icon_state = "gyro"
 	attach_icon = "gyro_a"
 	slot = "under"
 
 /obj/item/attachable/gyro/New()
 	..()
-	burst_scatter_mod = -2
-	movement_acc_penalty_mod = -3
+	burst_scatter_mod = -config.low_burst_scatter_penalty
+	movement_acc_penalty_mod = -config.med_movement_acc_penalty
 	scatter_unwielded_mod = -config.low_scatter_value
 	accuracy_unwielded_mod = config.min_hit_accuracy_mult
 	recoil_unwielded_mod = -config.low_recoil_value
-	
+
 /obj/item/attachable/lasersight
 	name = "laser sight"
-	desc = "A laser sight placed under the barrel. Significantly increases accuracy while moving, whether wielding or one-handed."
+	desc = "A laser sight placed under the barrel. Significantly increases one-handed accuracy and significantly reduces movement penalties to accuracy."
 	icon_state = "lasersight"
 	attach_icon = "lasersight_a"
 	slot = "under"
@@ -999,8 +1000,8 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/lasersight/New()
 	..()
-	accuracy_mod = config.med_hit_accuracy_mult
-	movement_acc_penalty_mod = -2
+	accuracy_mod = config.min_hit_accuracy_mult
+	movement_acc_penalty_mod = -config.min_burst_scatter_penalty
 	accuracy_unwielded_mod = config.med_hit_accuracy_mult
 
 
@@ -1081,7 +1082,7 @@ obj/item/attachable/attack_hand(var/mob/user as mob)
 
 /obj/item/attachable/burstfire_assembly
 	name = "burst fire assembly"
-	desc = "A mechanism re-assembly kit that allows for automatic fire, or more shots per burst if the weapon already has the ability. \nJust don't mind the increased scatter."
+	desc = "A mechanism re-assembly kit that allows for automatic fire, or more shots per burst if the weapon already has the ability. \nIncreases scatter and decreases accuracy."
 	icon_state = "rapidfire"
 	attach_icon = "rapidfire_a"
 	slot = "under"


### PR DESCRIPTION
-Recoil compensator no longer increases accuracy; instead it now has a unique niche significantly reducing recoil and spread, for both wielded and unwielded weapons.

-Stocks now increase instead of decrease accuracy penalties from movement.

-Stocks provide no benefit when one handing excepting minor benefits for the revolver (because it still applies penalties even then). As compensation their wielded recoil, scatter, and/or accuracy benefits have been increased.

-Stock wield delays changed to be proportionate to weapon size and mileage gained from the stock. 

-Made laser sight improve accuracy only because I can't see why it would ever decrease scatter; as compensation its movement penalty reduction has been increased.

-Gyro has been refocused on improving one-handed shooting by making, recoil, scatter and accuracy improvements exclusive to one handing. Further, its crippling fire delay increment has been removed, bringing it in line with other high-demand attachments for this slot.

-Vertical grip now reduces recoil by slightly more when wielded (not that I see this really coming up ever).