### PR TITLE
Devour Tweak

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -65,6 +65,10 @@
 		A.forceMove(loc)
 		if(ismob(A))
 			visible_message("<span class='danger'>[A] bursts out of [src]!</span>")
+			if(isliving(A))
+				var/mob/living/L = A
+				L.blinded = FALSE
+
 
 	. = ..()
 

--- a/code/modules/mob/living/carbon/xenomorph/Abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Abilities.dm
@@ -93,6 +93,10 @@
 			if(M.loc != X)
 				continue
 			M.forceMove(X.loc)
+			if(isliving(M))
+				var/mob/living/L = M
+				L.blinded = FALSE
+
 
 		X.visible_message("<span class='xenowarning'>\The [X] hurls out the contents of their stomach!</span>", \
 		"<span class='xenowarning'>You hurl out the contents of your stomach!</span>", null, 5)

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -277,6 +277,9 @@
 		for(var/atom/movable/S in stomach_contents)
 			stomach_contents.Remove(S)
 			S.forceMove(get_turf(src))
+			if(isliving(S))
+				var/mob/living/L = S
+				L.blinded = FALSE
 
 	if(contents.len) //Get rid of anything that may be stuck inside us as well
 		for(var/atom/movable/A in contents)

--- a/code/modules/mob/living/carbon/xenomorph/death.dm
+++ b/code/modules/mob/living/carbon/xenomorph/death.dm
@@ -77,6 +77,9 @@
 	for(var/atom/movable/A in stomach_contents)
 		stomach_contents.Remove(A)
 		A.forceMove(loc)
+		if(isliving(A))
+			var/mob/living/L = A
+			L.blinded = FALSE
 
 	round_statistics.total_xeno_deaths++
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -38,7 +38,7 @@ adjustFireLoss(-(maxHealth / 70 + 0.5 + (maxHealth / 70) * recovery_aura/2)*(m))
 				if(loc != zoom_turf || lying)
 					zoom_out()
 			update_progression()
-			update_evolving()	
+			update_evolving()
 			//Status updates, death etc.
 			handle_aura_emiter()
 			handle_aura_receiver()
@@ -103,6 +103,9 @@ adjustFireLoss(-(maxHealth / 70 + 0.5 + (maxHealth / 70) * recovery_aura/2)*(m))
 				if(M.loc != src)
 					continue
 				M.forceMove(loc)
+				if(isliving(M))
+					var/mob/living/L = M
+					L.blinded = FALSE
 	return TRUE
 
 /mob/living/carbon/Xenomorph/handle_statuses()
@@ -346,7 +349,7 @@ adjustFireLoss(-(maxHealth / 70 + 0.5 + (maxHealth / 70) * recovery_aura/2)*(m))
 			overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 		else
 			clear_fullscreen("blind")
-		
+
 		if(interactee)
 			interactee.check_eye(src)
 		else

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -97,7 +97,7 @@
 						return */
 		X.visible_message("<span class='danger'>[X] starts to devour [pulled]!</span>", \
 		"<span class='danger'>You start to devour [pulled]!</span>", null, 5)
-		if(do_after(X, 50, FALSE, 5, BUSY_ICON_HOSTILE))
+		if(do_after(X, min(30, 200 - pulled.traumatic_shock), FALSE, 5, BUSY_ICON_HOSTILE)) //devour delay scales with the victim's pain at the time it begins
 			if(X.pulling == pulled && !pulled.buckled && pulled.stat != DEAD && !X.stomach_contents.len) //make sure you've still got them in your claws, and alive
 				X.visible_message("<span class='warning'>[X] devours [pulled]!</span>", \
 				"<span class='warning'>You devour [pulled]!</span>", null, 5)
@@ -114,6 +114,9 @@
 				//Then, we place the mob where it ought to be
 				X.stomach_contents.Add(pulled)
 				pulled.forceMove(X)
+				pulled.blinded = TRUE //while in the stomach, victim is blinded.
+
+
 				return 1
 		if(!(pulled in X.stomach_contents))
 			to_chat(X, "<span class='warning'>You stop devouring \the [pulled]. \He probably tasted gross anyways.</span>")


### PR DESCRIPTION
-Devoured marines are now blinded for the duration of the devour, allowing aliens the opportunity to deposit them in unrecognizable locations.

-Devour delay now scales inversely with the pain the victim is in; the higher the pain (i.e. they're less able to resist), the faster it is completed, with a current max delay of 20 seconds vs a full health/no pain marine, and a minimum delay of 3 seconds. The delay is reduced by 1 second per 10 pain.