### PR TITLE
Fix duplicate constant issues.

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -1,5 +1,5 @@
-#define CLOSED 0
-#define OPEN 1
+#define D_CLOSED 0
+#define D_OPEN 1
 
 //NOT using the existing /obj/machinery/door type, since that has some complications on its own, mainly based on its
 //machineryness
@@ -14,7 +14,7 @@
 	icon_state = "metal"
 
 	var/mineralType = "metal"
-	var/state = CLOSED
+	var/state = D_CLOSED
 	var/isSwitchingStates = FALSE
 	var/hardness = 1
 	var/oreAmount = 7
@@ -77,7 +77,7 @@
 	sleep(10)
 	density = FALSE
 	opacity = FALSE
-	state = OPEN
+	state = D_OPEN
 	update_icon()
 	isSwitchingStates = FALSE
 
@@ -89,7 +89,7 @@
 	sleep(10)
 	density = TRUE
 	opacity = TRUE
-	state = CLOSED
+	state = D_CLOSED
 	update_icon()
 	isSwitchingStates = FALSE
 
@@ -219,7 +219,7 @@
 	sleep(10)
 	density = FALSE
 	opacity = FALSE
-	state = OPEN
+	state = D_OPEN
 	update_icon()
 	isSwitchingStates = FALSE
 
@@ -230,7 +230,7 @@
 	sleep(10)
 	density = TRUE
 	opacity = TRUE
-	state = CLOSED
+	state = D_CLOSED
 	update_icon()
 	isSwitchingStates = FALSE
 
@@ -244,8 +244,8 @@
 /obj/structure/mineral_door/wood/open
 	density = FALSE
 	opacity = FALSE
-	state = OPEN
+	state = D_OPEN
 	icon_state = "woodopen"
 
-#undef CLOSED
-#undef OPEN
+#undef D_CLOSED
+#undef D_OPEN

--- a/code/global.dm
+++ b/code/global.dm
@@ -240,7 +240,6 @@ var/list/AAlarmWireColorToIndex
 #define SPEED_OF_LIGHT_SQ 9e+16
 #define FIRE_DAMAGE_MODIFIER 0.0215 //Higher values result in more external fire damage to the skin (default 0.0215)
 #define AIR_DAMAGE_MODIFIER 2.025 //More means less damage from hot air scalding lungs, less = more damage. (default 2.025)
-#define INFINITY 1.#INF
 
 	//Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN 1024

--- a/code/modules/mob/living/carbon/monkey/update_icons.dm
+++ b/code/modules/mob/living/carbon/monkey/update_icons.dm
@@ -4,7 +4,7 @@
 #define M_HANDCUFF_LAYER		6
 #define M_L_HAND_LAYER			5
 #define M_R_HAND_LAYER			4
-#define TARGETED_LAYER			3
+#define M_TARGETED_LAYER		3
 #define M_FIRE_LAYER			2
 #define M_BURST_LAYER			1
 #define M_TOTAL_LAYERS			8
@@ -98,13 +98,13 @@
 
 //Call when target overlay should be added/removed
 /mob/living/carbon/monkey/update_targeted()
-	remove_overlay(TARGETED_LAYER)
+	remove_overlay(M_TARGETED_LAYER)
 	if (targeted_by && target_locked)
-		overlays_standing[TARGETED_LAYER]	= image("icon"=target_locked, "layer" =-TARGETED_LAYER)
+		overlays_standing[M_TARGETED_LAYER]	= image("icon"=target_locked, "layer" =-M_TARGETED_LAYER)
 	else if (!targeted_by && target_locked)
 		cdel(target_locked)
 		target_locked = null
-	apply_overlay(TARGETED_LAYER)
+	apply_overlay(M_TARGETED_LAYER)
 
 /mob/living/carbon/monkey/update_burst()
 	remove_overlay(M_BURST_LAYER)
@@ -126,7 +126,7 @@
 #undef M_HANDCUFF_LAYER
 #undef M_L_HAND_LAYER
 #undef M_R_HAND_LAYER
-#undef TARGETED_LAYER
+#undef M_TARGETED_LAYER
 #undef M_FIRE_LAYER
 #undef M_BURST_LAYER
 #undef M_TOTAL_LAYERS

--- a/code/modules/shuttles/shuttle_hangar.dm
+++ b/code/modules/shuttles/shuttle_hangar.dm
@@ -10,24 +10,6 @@
 	//var/obj/effect/elevator/supply/SE
 	//var/obj/effect/elevator/supply/NW
 	//var/obj/effect/elevator/supply/NE
-	var/HangarElevatorUpper_x
-	var/HangarElevatorUpper_y
-	var/HangarElevatorUpper_z
-	var/HangarElevatorLower_x
-	var/HangarElevatorLower_y
-	var/HangarElevatorLower_z
-
-/datum/shuttle/ferry/hangar/New()
-	..()
-
-	var/turf/HangarUpperElevatorLoc = get_turf(HangarUpperElevator)
-	var/turf/HangarLowerElevatorLoc = get_turf(HangarLowerElevator)
-	HangarElevatorUpper_x = HangarUpperElevatorLoc.x
-	HangarElevatorUpper_y = HangarUpperElevatorLoc.y
-	HangarElevatorUpper_z = HangarUpperElevatorLoc.z
-	HangarElevatorLower_x = HangarLowerElevatorLoc.x
-	HangarElevatorLower_y = HangarLowerElevatorLoc.y
-	HangarElevatorLower_z = HangarLowerElevatorLoc.z
 
 /datum/shuttle/ferry/hangar/process()
 
@@ -78,8 +60,8 @@
 	lower_railings(1)
 	if(!at_station())
 		moving_status = SHUTTLE_INTRANSIT
-		playsound(locate(HangarElevatorUpper_x,HangarElevatorUpper_y,HangarElevatorUpper_z), 'sound/effects/bang.ogg', 40, 0)
-		playsound(locate(HangarElevatorLower_x,HangarElevatorLower_y,HangarElevatorLower_z), 'sound/effects/bang.ogg', 20, 0)
+		playsound(HangarUpperElevator, 'sound/effects/bang.ogg', 40, 0)
+		playsound(HangarLowerElevator, 'sound/effects/bang.ogg', 20, 0)
 		lower_railings(1)
 
 		if(!destination)
@@ -116,8 +98,8 @@
 		var/area/away_area = get_location_area(away_location)
 		moving_status = SHUTTLE_INTRANSIT
 
-		playsound(locate(HangarElevatorLower_x,HangarElevatorLower_y,HangarElevatorLower_z), 'sound/machines/elevator_move.ogg', 50, 0)
-		playsound(locate(HangarElevatorUpper_x,HangarElevatorUpper_y,HangarElevatorUpper_z), 'sound/machines/elevator_move.ogg', 50, 0)
+		playsound(HangarUpperElevator, 'sound/machines/elevator_move.ogg', 50, 0)
+		playsound(HangarLowerElevator, 'sound/machines/elevator_move.ogg', 50, 0)
 
 		//If we are at the away_area then we are just pretending to move, otherwise actually do the move
 		if (origin != away_area)
@@ -158,8 +140,8 @@
 			spawn()
 				M.close()
 	if(effective)
-		playsound(locate(HangarElevatorUpper_x,HangarElevatorUpper_y,HangarElevatorUpper_z), 'sound/machines/elevator_openclose.ogg', 50, 0)
-		playsound(locate(HangarElevatorLower_x,HangarElevatorLower_y,HangarElevatorLower_z), 'sound/machines/elevator_openclose.ogg', 50, 0)
+		playsound(HangarUpperElevator, 'sound/machines/elevator_openclose.ogg', 50, 0)
+		playsound(HangarLowerElevator, 'sound/machines/elevator_openclose.ogg', 50, 0)
 
 
 /datum/shuttle/ferry/hangar/proc/lower_railings(var/force=0)
@@ -170,11 +152,11 @@
 	if(at_station())
 		railing_id = railing_lower_id
 		other_id = railing_upper_id
-		soundturf = locate(HangarElevatorLower_x,HangarElevatorLower_y,HangarElevatorLower_z)
+		soundturf = HangarLowerElevator
 	else
 		railing_id = railing_upper_id
 		other_id = railing_lower_id
-		soundturf = locate(HangarElevatorUpper_x,HangarElevatorUpper_y,HangarElevatorUpper_z)
+		soundturf = HangarUpperElevator
 	for(var/obj/machinery/door/poddoor/M in machines)
 		if(M.id == railing_id && M.density)
 			effective = 1


### PR DESCRIPTION
Fixes having duplicate definitions of `TARGETED_LAYER`, `INFINITY` and `OPEN`. Blame #235 and #176 and the code we inherited.

Fixes some runtime errors we also inherited due to rather curious code for the hangar elevator (used to move the tank from the tank bay). The code was trying to get the `x`, `y` and `z` variables of `HangarUpperElevator` and `HangarLowerElevator` before they were created in their landmarks. This would be used later on when the ship crashes in order to play the crashing sound of the elevator falling, which can actually simply use the location of the elevator without the need of those intermediary steps.