### PR TITLE
No scout xeno left behind

### DIFF
--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -411,7 +411,11 @@
 	var/list/with_queen = list()
 	for(var/mob/living/carbon/Xenomorph/xeno in living_xeno_list)
 		if(xeno.hivenumber != XENO_HIVE_NORMAL) continue
-		if(xeno.loc.z == hive.living_xeno_queen.loc.z) // yes loc because of vent crawling
+		if(xeno.loc.z == hive.living_xeno_queen.loc.z || xeno.loc.z != 1) // yes loc because of vent crawling
+			/* or != 1 because '#include "maps\Z.01.LV624.dmm"' is the first map loaded in ColonialMarinesALPHA.dme,
+			 * i.e. this assumes the first map will always be the planet/station map,
+			 * and it is assumed all xenos not on the planet/station can be killed/lose or can win
+			 */
 			with_queen += xeno
 		else
 			left_behind += xeno

--- a/code/modules/shuttles/marine_ferry.dm
+++ b/code/modules/shuttles/marine_ferry.dm
@@ -411,11 +411,7 @@
 	var/list/with_queen = list()
 	for(var/mob/living/carbon/Xenomorph/xeno in living_xeno_list)
 		if(xeno.hivenumber != XENO_HIVE_NORMAL) continue
-		if(xeno.loc.z == hive.living_xeno_queen.loc.z || xeno.loc.z != 1) // yes loc because of vent crawling
-			/* or != 1 because '#include "maps\Z.01.LV624.dmm"' is the first map loaded in ColonialMarinesALPHA.dme,
-			 * i.e. this assumes the first map will always be the planet/station map,
-			 * and it is assumed all xenos not on the planet/station can be killed/lose or can win
-			 */
+		if(xeno.loc.z == hive.living_xeno_queen.loc.z || xeno.loc.z in MAIN_SHIP_AND_DROPSHIPS_Z_LEVELS) // yes loc because of vent crawling, xeno must be with queen or on round end Z levels
 			with_queen += xeno
 		else
 			left_behind += xeno


### PR DESCRIPTION
Xenos aboard the Almayer complained they were being deleted despite being forward troops. I've added a Z level check to prevent this (if you're in transit or on the Almayer, you're safe). This doesn't remove the standard check of being with the Queen in case future behaviour involves the Queen being on neither of those Z levels.

One small thing I noticed was that there was no define for the planet/station, or rather there's one line in this file that assumes said Z level will always be 1. In practice this probably won't ever have an impact.