### PR TITLE
Removes zero percent message warning

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -1,4 +1,5 @@
 /client/proc/play_imported_sound(S as sound)
+	var/midi_warning = ""
 	set category = "Fun"
 	set name = "Play Imported Sound"
 	set desc = "Play a sound imported from anywhere on your computer."
@@ -33,7 +34,11 @@
 	midi_playing = 1
 	spawn(midi_playing_timer)
 		midi_playing = 0
-		message_admins("'Silence Current Midi' usage reporting 30-sec timer has expired. [total_silenced] player(s) silenced the midi in the first 30 seconds out of [heard_midi] total player(s) that have 'Play Admin Midis' enabled. <span style='color: red'>[round((total_silenced / heard_midi) * 100)]% of players don't want to hear it, and likely more if the midi is longer than 30 seconds.</span>")
+		if(heard_midi == 0)
+			message_admins("No-one heard the midi")
+		if((total_silenced / heard_midi) != 0)
+			midi_warning = " <span style='color: red'>[round((total_silenced / heard_midi) * 100)]% of players don't want to hear it, and likely more if the midi is longer than 30 seconds.</span>"
+		message_admins("'Silence Current Midi' usage reporting 30-sec timer has expired. [total_silenced] player(s) silenced the midi in the first 30 seconds out of [heard_midi] total player(s) that have 'Play Admin Midis' enabled.[midi_warning]")
 		heard_midi = 0
 		total_silenced = 0
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -36,6 +36,8 @@
 		midi_playing = 0
 		if(heard_midi == 0)
 			message_admins("No-one heard the midi")
+			total_silenced = 0
+			return
 		if((total_silenced / heard_midi) != 0)
 			midi_warning = " <span style='color: red'>[round((total_silenced / heard_midi) * 100)]% of players don't want to hear it, and likely more if the midi is longer than 30 seconds.</span>"
 		message_admins("'Silence Current Midi' usage reporting 30-sec timer has expired. [total_silenced] player(s) silenced the midi in the first 30 seconds out of [heard_midi] total player(s) that have 'Play Admin Midis' enabled.[midi_warning]")


### PR DESCRIPTION
Oh no, zero percent turned off admin midis, you should be careful.

Also added an exit in case a divide by zero occurs because that would be bad. Though I don't know what kind of admin would play midis whilst muting them in preferences.