### PR TITLE
Extended explosion parameters, more work required

### DIFF
--- a/code/WorkInProgress/Cael_Aislinn/meteor_battery.dm
+++ b/code/WorkInProgress/Cael_Aislinn/meteor_battery.dm
@@ -20,11 +20,13 @@
 	spawn(0)
 		if(istype(A,/obj/effect/meteor))
 			del(A)
-		explode()
+			explode("hit meteor")
+		else
+			explode("hit [A.name]")
 	return
 
-/obj/item/projectile/missile/proc/explode()
-	explosion(src.loc, 1, 1, 2, 7, 0)
+/obj/item/projectile/missile/proc/explode(cause)
+	explosion(src.loc, 1, 1, 2, 7, 0, src.name, cause)
 	playsound(src.loc, "explosion", 50, 1)
 	del(src)
 
@@ -35,7 +37,7 @@
 /obj/item/projectile/missile/attackby(obj/item/weapon/W, mob/user)
 	//can't touch this
 	..()
-	explode()
+	explode("hit by [user.name]")
 
 /obj/machinery/meteor_battery
 	name = "meteor battery"

--- a/code/datums/spells/explosion.dm
+++ b/code/datums/spells/explosion.dm
@@ -10,6 +10,6 @@
 /obj/effect/proc_holder/spell/targeted/explosion/cast(list/targets)
 
 	for(var/mob/living/target in targets)
-		explosion(target.loc,ex_severe,ex_heavy,ex_light,ex_flash)
+		explosion(target.loc,ex_severe,ex_heavy,ex_light,ex_flash, "explosion spell", "targeted [target.name]")
 
 	return

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -219,7 +219,7 @@
 	proj_step_delay = 1
 
 /obj/effect/proc_holder/spell/turf/fireball/cast(var/turf/T)
-	explosion(T, -1, 1, 2, 3)
+	explosion(T, -1, 1, 2, 3, name)
 
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/fireball

--- a/code/game/gamemodes/colonialmarines/halloween2016.dm
+++ b/code/game/gamemodes/colonialmarines/halloween2016.dm
@@ -343,15 +343,15 @@
 /obj/item/device/omega_array/proc/update_health()
 	if(health <= 0)
 		visible_message("<span class='warning'>[src] sparks and begins to violently shake!</span>")
-		destroy()
+		destroy("health depleted")
 
-/obj/item/device/omega_array/proc/destroy()
+/obj/item/device/omega_array/proc/destroy(cause)
 	if(ticker && ticker.mode && ticker.mode.type == /datum/game_mode/colonialmarines_halloween_2016)
 		var/datum/game_mode/colonialmarines_halloween_2016/M = ticker.mode
 		M.mcguffin = null
 	var/detonate_location = get_turf(src)
 	cdel(src)
-	explosion(detonate_location,2,3,4)
+	explosion(detonate_location, 2, 3, 4, name, cause)
 
 /obj/item/device/omega_array/control
 	New()

--- a/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
+++ b/code/game/gamemodes/colonialmarines/whiskey_outpost.dm
@@ -1487,13 +1487,13 @@
 		var/turf/target_4 = locate(T.x - (offset_x*2),T.y - (offset_y*2),T.z)
 		sleep(50) //AWW YEAH
 		flame_radius(3,target)
-		explosion(target,  -1, 2, 3, 5)
+		explosion(target,  -1, 2, 3, 5, "[name], napalm", "activated by [user.name]")
 		flame_radius(3,target_2)
-		explosion(target_2,  -1, 2, 3, 5)
+		explosion(target_2,  -1, 2, 3, 5, "[name], napalm", "activated by [user.name]")
 		flame_radius(3,target_3)
-		explosion(target_3,  -1, 2, 3, 5)
+		explosion(target_3,  -1, 2, 3, 5, "[name], napalm", "activated by [user.name]")
 		flame_radius(3,target_4)
-		explosion(target_4,  -1, 2, 3, 5)
+		explosion(target_4,  -1, 2, 3, 5, "[name], napalm", "activated by [user.name]")
 		sleep(1)
 		cdel(lasertarget)
 		lazing = 0
@@ -1524,11 +1524,11 @@
 		var/turf/target_3 = locate(T.x + rand(-2,2),T.y + rand(-2,2),T.z)
 		if(target && istype(target))
 			cdel(lasertarget)
-			explosion(target, -1, HE_power, con_power, con_power) //Kaboom!
+			explosion(target, -1, HE_power, con_power, con_power, "[name], mortar", "activated by [user.name]") //Kaboom!
 			sleep(rand(15,30)) //This is all better done in a for loop, but I am mad lazy
-			explosion(target_2, -1, HE_power, con_power, con_power)
+			explosion(target_2, -1, HE_power, con_power, con_power, "[name], mortar", "activated by [user.name]")
 			sleep(rand(15,30))
-			explosion(target_3, -1, HE_power, con_power, con_power)
+			explosion(target_3, -1, HE_power, con_power, con_power, "[name], mortar", "activated by [user.name]")
 			lazing = 0
 			laz_b = 1
 			sleep(6000)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -7,12 +7,13 @@
 	else		return dy + (0.5*dx)
 
 
-/proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = 0, flame_range = 0)
+/proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = 0, flame_range = 0, verbose_cause = "no explanation")
+	var/explosion_source = src.name
 	src = null	//so we don't abort once src is deleted
 	spawn(0)
 		if(config.use_recursive_explosions)
 			var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
-			explosion_rec(epicenter, power)
+			explosion_rec(epicenter, power, verbose_cause, explosion_source)
 			return
 
 		var/start = world.timeofday
@@ -61,8 +62,8 @@
 						if(!istype(M.loc, /turf/open/space))
 							M << 'sound/effects/explosionfar.ogg'
 		if(adminlog)
-			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
-			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ")
+			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]), from atom [explosion_source], cause: [verbose_cause] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
+			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name], from atom named [explosion_source], cause: [verbose_cause] ")
 
 		var/approximate_intensity = (devastation_range * 3) + (heavy_impact_range * 2) + light_impact_range
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -7,7 +7,7 @@
 	else		return dy + (0.5*dx)
 
 
-/proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = 0, flame_range = 0, verbose_cause = "no explanation")
+/proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, verbose_cause = "no explanation", adminlog = 1, z_transfer = 0, flame_range = 0)
 	var/explosion_source = src.name
 	src = null	//so we don't abort once src is deleted
 	spawn(0)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -7,8 +7,7 @@
 	else		return dy + (0.5*dx)
 
 
-/proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, verbose_cause = "no explanation", adminlog = 1, z_transfer = 0, flame_range = 0)
-	var/explosion_source = src.name
+/proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, explosion_source = "unknown source", verbose_cause = "no explanation", adminlog = 1, z_transfer = 0, flame_range = 0)
 	src = null	//so we don't abort once src is deleted
 	spawn(0)
 		if(config.use_recursive_explosions)
@@ -62,7 +61,7 @@
 						if(!istype(M.loc, /turf/open/space))
 							M << 'sound/effects/explosionfar.ogg'
 		if(adminlog)
-			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]), from atom [explosion_source], cause: [verbose_cause] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
+			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]), from atom name [explosion_source], cause: [verbose_cause] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
 			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name], from atom named [explosion_source], cause: [verbose_cause] ")
 
 		var/approximate_intensity = (devastation_range * 3) + (heavy_impact_range * 2) + light_impact_range

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -10,7 +10,7 @@
 var/list/explosion_turfs = list()
 var/explosion_in_progress = 0
 
-proc/explosion_rec(turf/epicenter, power, verbose cause = "no explanation", explosion_source = "unknown")
+proc/explosion_rec(turf/epicenter, power, verbose_cause = "no explanation", explosion_source = "unknown")
 	var/loopbreak = 0
 	while(explosion_in_progress)
 		if(loopbreak >= 15) return

--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -10,7 +10,7 @@
 var/list/explosion_turfs = list()
 var/explosion_in_progress = 0
 
-proc/explosion_rec(turf/epicenter, power)
+proc/explosion_rec(turf/epicenter, power, verbose cause = "no explanation", explosion_source = "unknown")
 	var/loopbreak = 0
 	while(explosion_in_progress)
 		if(loopbreak >= 15) return
@@ -21,8 +21,8 @@ proc/explosion_rec(turf/epicenter, power)
 	epicenter = get_turf(epicenter)
 	if(!epicenter) return
 
-	message_admins("Explosion with size ([power]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z])")
-	log_game("Explosion with size ([power]) in area [epicenter.loc.name] ")
+	message_admins("Explosion with size ([power]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z], from atom [explosion_source], cause: [verbose_cause])")
+	log_game("Explosion with size ([power]) in area [epicenter.loc.name], from atom named [explosion_source], cause: [verbose_cause] ")
 
 	playsound(epicenter, 'sound/effects/explosionfar.ogg', 75, 1, max(round(8*power,1),14) )
 	playsound(epicenter, "explosion", 75, 1, max(round(4*power,1),7) )


### PR DESCRIPTION
Trying to make explosion logging better, at least so you can search who or what in the logs.

- [x] add parameters to both explosion procs
- [ ] go through all explosion() calls to try and find a reason for as many as I can
- [ ] see if adding a list of mobs affected would be painful