### PR TITLE
Turns chat, github and patreon links into configs

### DIFF
--- a/code/controllers/settings/configuration.dm
+++ b/code/controllers/settings/configuration.dm
@@ -94,6 +94,9 @@
 	var/wikiurl
 	var/forumurl
 	var/rulesurl
+	var/chaturl
+	var/donationurl
+	var/bugtrackerurl
 
 	//Alert level description
 	var/alert_desc_green = "All security alerts have passed."
@@ -338,6 +341,15 @@
 
 		if ("rulesurl")
 			config.rulesurl = value
+
+		if ("chaturl")
+			config.chaturl = value
+
+		if ("donationurl")
+			config.donationurl = value
+
+		if ("bugtrackerurl")
+			config.bugtrackerurl = value
 
 		if ("guest_jobban")
 			config.guest_jobban = 1

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -255,8 +255,8 @@ var/world_topic_spam_protect_time = world.timeofday
 	var/s = ""
 
 	if (config && config.server_name)
-		s += "<a href=\"[config.forumurl]\"><b>[config.server_name] &#8212; [MAIN_SHIP_NAME]</b>"
-		s += "<br><img src=\"[config.forumurl]/byond_hub_logo.jpg\"></a>"
+		s += "<a href=\"[config.chaturl]\"><b>[config.server_name] &#8212; [MAIN_SHIP_NAME]</b></a>"
+		// s += "<br><img src=\"[config.chaturl]/byond_hub_logo.jpg\">"
 		// s += "<a href=\"http://goo.gl/04C5lP\">Wiki</a>|<a href=\"http://goo.gl/hMmIKu\">Rules</a>"
 		if(ticker)
 			if(master_mode)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -255,12 +255,25 @@ var/world_topic_spam_protect_time = world.timeofday
 	var/s = ""
 
 	if (config && config.server_name)
-		s += "<a href=\"[config.chaturl]\"><b>[config.server_name] &#8212; [MAIN_SHIP_NAME]</b></a>"
-		// s += "<br><img src=\"[config.forumurl]/byond_hub_logo.jpg\">"
-		// s += "<a href=\"http://goo.gl/04C5lP\">Wiki</a>|<a href=\"http://goo.gl/hMmIKu\">Rules</a>"
+		if(config.chaturl)
+			s += "<a href=\"[config.chaturl]\"><b>[config.server_name] &#8212; [MAIN_SHIP_NAME]</a></b>"
+		else
+			s += "<b>[config.server_name] &#8212; [MAIN_SHIP_NAME]</b>"
 		if(ticker)
 			if(master_mode)
-				s += "<br>Map: <b>[map_tag]</b>"
+				switch(map_tag)
+					if("Ice Colony")
+						s += "<br>Map: <a href=\"[config.icecolony_url]\"><b>[map_tag]</a></b>"
+					if("LV-624")
+						s += "<br>Map: <a href=\"[config.lv624_url]\"><b>[map_tag]</a></b>"
+					if("Solaris Ridge")
+						s += "<br>Map: <a href=\"[config.bigred_url]\"><b>[map_tag]</a></b>"
+					if("Prison Station")
+						s += "<br>Map: <a href=\"[config.prisonstation_url]\"><b>[map_tag]</a></b>"
+					if("Whiskey Outpost")
+						s += "<br>Map: <a href=\"[config.whiskeyoutpost_url]\"><b>[map_tag]</a></b>"
+					else
+						s += "<br>Map: <b>[map_tag]</b>"
 				s += "<br>Mode: <b>[ticker.mode.name]</b>"
 				s += "<br>Round time: <b>[duration2text()]</b>"
 		else

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -256,7 +256,7 @@ var/world_topic_spam_protect_time = world.timeofday
 
 	if (config && config.server_name)
 		s += "<a href=\"[config.chaturl]\"><b>[config.server_name] &#8212; [MAIN_SHIP_NAME]</b></a>"
-		// s += "<br><img src=\"[config.chaturl]/byond_hub_logo.jpg\">"
+		// s += "<br><img src=\"[config.forumurl]/byond_hub_logo.jpg\">"
 		// s += "<a href=\"http://goo.gl/04C5lP\">Wiki</a>|<a href=\"http://goo.gl/hMmIKu\">Rules</a>"
 		if(ticker)
 			if(master_mode)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -22,18 +22,23 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	var/msg
 	var/list/type = list ("Suggestion / Bug Report", "Gameplay / Roleplay Issue", "Admins Spawn Shit")
 	var/selected_type = input("Pick a category.", "Admin Help", null, null) as null|anything in type
-	if(selected_type == "Gameplay / Roleplay Issue")
-		msg = input("Please enter your message:", "Admin Help", null, null) as message|null
-
-	if(selected_type == "Suggestion / Bug Report")
-		switch(alert("Adminhelps are not for suggestions or bug reports - issues should be posted on our Github, and suggestions on our forums. #WHENYOUCODEIT",,"Go to Github","Go to forums","Cancel"))
-			if("Go to Github")
-				src << link("https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/issues")
-			if("Go to forums")
-				src << link("https://tgstation13.org/phpBB/viewforum.php?f=65")
-
-	if(selected_type == "Admins Spawn Shit")
-		src << "\red <B>No</B>"
+	switch(selected_type)
+		if("Gameplay / Roleplay Issue")
+			msg = input("Please enter your message:", "Admin Help", null, null) as message|null
+		if("Suggestion / Bug Report")
+			switch(alert("Adminhelps are not for suggestions or bug reports - issues should be posted on our Github, and suggestions on our forums. #WHENYOUCODEIT",,"Go to Github","Go to forums","Cancel"))
+				if("Go to Github")
+					if(config.bugtrackerurl)
+						src << link(config.bugtrackerurl)
+					else
+						to_chat(src, "<span class='warning'>The bug tracker URL is not set in the server configuration.</span>")
+				if("Go to forums")
+					if(config.forumurl)
+						src << link(config.forumurl)
+					else
+						to_chat(src, "<span class='warning'>The forum URL is not set in the server configuration.</span>")
+		if("Admins Spawn Shit")
+			to_chat(src, "<span class='warning'>No</span>")
 			
 	var/selected_upper = uppertext(selected_type)
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -187,16 +187,25 @@ GUEST_BAN
 #SERVER server.net:port
 
 ## forum address
-FORUMURL https://tgstation13.org/phpBB/
+FORUMURL https://tgstation13.org/phpBB/viewforum.php?f=64
 
 ## Wiki address
-WIKIURL https://tgstation13.org/wiki
+WIKIURL https://tgstation13.org/wiki/DMCA
 
 ## Rules address
 RULESURL https://tgstation13.org/wiki/DMCA_Rules
 
+## Chat address
+CHATURL https://discord.gg/2dFpfNE
+
+## Donation address
+DONATIONURL https://www.patreon.com/tgstation
+
+## Bug tracker address
+BUGTRACKERURL https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/issues
+
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
-BANAPPEALS https://cm-ss13.com/viewforum.php?f=76
+BANAPPEALS https://cc.ddmers.com/dmca/
 
 ## In-game features
 ## spawns a spellbook which gives object-type spells instead of verb-type spells for the wizard

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -181,16 +181,25 @@ GUEST_BAN
 #SERVER server.net:port
 
 ## forum address
-FORUMURL https://cm-ss13.com/
+FORUMURL https://tgstation13.org/phpBB/
 
 ## Wiki address
-WIKIURL https://cm-ss13/wiki/
+WIKIURL https://tgstation13.org/wiki/
 
 ## Rules address
-RULESURL https://cm-ss13.com/viewtopic.php?f=57&t=5094
+RULESURL https://tgstation13.org/wiki/Rules
+
+## Chat address
+CHATURL https://discord.tgstation13.org/
+
+## Donation address
+DONATIONURL https://www.patreon.com/tgstation
+
+## Bug tracker address
+BUGTRACKERURL https://github.com/tgstation/tgstation/issues
 
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
-BANAPPEALS https://cm-ss13.com/viewforum.php?f=76
+BANAPPEALS https://tgstation13.org/phpBB/viewforum.php?f=7
 
 ## In-game features
 ## spawns a spellbook which gives object-type spells instead of verb-type spells for the wizard

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -3,7 +3,7 @@
 	set name = "wiki"
 	set desc = "Visit the wiki."
 	set hidden = 1
-	if( config.wikiurl )
+	if(config.wikiurl)
 		if(alert("This will open the wiki in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		src << link(config.wikiurl)
@@ -15,7 +15,7 @@
 	set name = "forum"
 	set desc = "Visit the forum."
 	set hidden = 1
-	if( config.forumurl )
+	if(config.forumurl)
 		if(alert("This will open the forum in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		src << link(config.forumurl)
@@ -27,7 +27,7 @@
 	set name = "rules"
 	set desc = "Read our rules."
 	set hidden = 1
-	if( config.rulesurl )
+	if(config.rulesurl)
 		if(alert("This will open the rules in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		src << link(config.rulesurl)
@@ -39,7 +39,7 @@
 	set name = "Patreon"
 	set desc = "Like our server? Buy us and get satisfaction for your efforts."
 	set hidden = 1
-	if( config.donationurl )
+	if(config.donationurl)
 		if(alert("This will open our donation page in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		src << link(config.donationurl)
@@ -51,7 +51,7 @@
 	set name = "Submit Bug"
 	set desc = "Submit a bug."
 	set hidden = 1
-	if( config.bugtrackerurl )
+	if(config.bugtrackerurl)
 		if(alert("This will open our bug tracker page in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		src << link(config.bugtrackerurl)

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -8,7 +8,7 @@
 			return
 		src << link(config.wikiurl)
 	else
-		src << "\red The wiki URL is not set in the server configuration."
+		to_chat(src, "<span class='warning'>The wiki URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/forum()
@@ -20,7 +20,7 @@
 			return
 		src << link(config.forumurl)
 	else
-		src << "\red The forum URL is not set in the server configuration."
+		to_chat(src, "<span class='warning'>The forum URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/rules()
@@ -32,25 +32,31 @@
 			return
 		src << link(config.rulesurl)
 	else
-		src << "\red The rules URL is not set in the server configuration."
+		to_chat(src, "<span class='warning'>The rules URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/patreon()
 	set name = "Patreon"
 	set desc = "Like our server? Buy us and get satisfaction for your efforts."
 	set hidden = 1
-
-	src << "<br>View our donation page for more info: https://www.patreon.com/tgstation.<br>"
+	if( config.donationurl )
+		if(alert("This will open our donation page in your browser. Are you sure?",,"Yes","No")=="No")
+			return
+		src << link(config.donationurl)
+	else
+		to_chat(src, "<span class='warning'>The donation URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/submitbug()
 	set name = "Submit Bug"
 	set desc = "Submit a bug."
 	set hidden = 1
-
-	if(alert("Please search for the bug first to make sure you aren't posting a duplicate.",,"Ok","Cancel")=="Cancel")
-		return
-	src << link("https://github.com/ColonialMarines-Mirror/ColonialMarines-2018")
+	if( config.bugtrackerurl )
+		if(alert("This will open our bug tracker page in your browser. Are you sure?",,"Yes","No")=="No")
+			return
+		src << link(config.bugtrackerurl)
+	else
+		to_chat(src, "<span class='warning'>The bug tracker URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/webmap()


### PR DESCRIPTION
Makes it easier for downstreams to set up their own without needing to change the code.
Cleans code a little.
Standard configs are DMCA. 
Example configs are /tg/, no longer CM.