### PR TITLE
Xeno healing rework and fixes

### DIFF
--- a/code/_onclick/ventcrawl.dm
+++ b/code/_onclick/ventcrawl.dm
@@ -10,9 +10,6 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 			return 0
 	return 1
 
-// Vent crawling whitelisted items, whoo
-/mob/living
-	var/canEnterVentWith = "/obj/item/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0&/obj/item/verbs=0"
 
 /mob/living/click(var/atom/A, var/list/mods)
 	if (..())

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -383,8 +383,3 @@
 //called when a mob tries to breathe while inside us.
 /atom/movable/proc/handle_internal_lifeform(mob/lifeform_inside_me)
 	. = return_air()
-
-/atom/movable/proc/update_action_button_icons()
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -384,3 +384,7 @@
 /atom/movable/proc/handle_internal_lifeform(mob/lifeform_inside_me)
 	. = return_air()
 
+/atom/movable/proc/update_action_button_icons()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.update_button_icon()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -113,23 +113,28 @@ Airlock index -> wire color are { 9, 4, 6, 7, 5, 8, 1, 2, 3 }.
 	tiles_with = list(
 		/turf/closed/wall)
 
-/obj/machinery/door/airlock/bumpopen(mob/living/user as mob) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
-	if(!issilicon(usr))
-		if(src.isElectrified())
-			if(!src.justzap)
-				if(src.shock(user, 100))
-					src.justzap = 1
-					spawn (openspeed)
-						src.justzap = 0
-					return
-			else /*if(src.justzap)*/
+/obj/machinery/door/airlock/bumpopen(mob/living/user) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
+	if(issilicon(user))
+		return ..(user)
+	if(iscarbon(user) && isElectrified())
+		if(!justzap)
+			if(shock(user, 100))
+				justzap = TRUE
+				spawn (openspeed)
+					justzap = FALSE
 				return
-		else if(user.hallucination > 50 && prob(10) && src.operating == 0)
-			to_chat(user, "\red <B>You feel a powerful shock course through your body!</B>")
-			user.halloss += 10
-			user.stunned += 10
+		else /*if(justzap)*/
 			return
-	..(user)
+	else if(ishuman(user) && user.hallucination > 50 && prob(10) && !operating)
+		var/mob/living/carbon/human/H = user
+		if(H.gloves)
+			to_chat(H, "\red <B>You feel a powerful shock course through your body!</B>")
+			var/obj/item/clothing/gloves/G = H.gloves
+			if(G.siemens_coefficient)//not insulated
+				H.halloss += 10
+				H.stunned += 10
+				return
+	return ..(user)
 
 /obj/machinery/door/airlock/bumpopen(mob/living/simple_animal/user as mob)
 	..(user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -680,8 +680,3 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 //Note that this is overriden by every proc concerning a child of obj unless inherited
 /obj/item/attack_alien(mob/living/carbon/Xenomorph/M)
 	return FALSE
-
-/obj/item/proc/update_action_button_icons()
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -680,3 +680,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 //Note that this is overriden by every proc concerning a child of obj unless inherited
 /obj/item/attack_alien(mob/living/carbon/Xenomorph/M)
 	return FALSE
+
+/obj/item/proc/update_action_button_icons()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.update_button_icon()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -681,3 +681,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/attack_alien(mob/living/carbon/Xenomorph/M)
 	return FALSE
 
+/obj/item/proc/update_action_button_icons()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.update_button_icon()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -184,25 +184,7 @@ cases. Override_icon_state should be a list.*/
 
 
 /obj/item/attack_paw(mob/user as mob)
-
-	if(anchored)
-		to_chat(user, "[src] is anchored to the ground.")
-		return
-
-	if (istype(src.loc, /obj/item/storage))
-		var/obj/item/storage/S = src.loc
-		S.remove_from_storage(src, user.loc)
-
-	src.throwing = FALSE
-	if (loc == user)
-		if(!user.drop_inv_item_on_ground(src))
-			return
-	else
-		user.next_move = max(user.next_move+2,world.time + 2)
-	if(!disposed) //item may have been cdel'd by the drop above.
-		pickup(user)
-		if(!user.put_in_active_hand(src))
-			dropped(user)
+	return attack_hand(user)
 
 // Due to storage type consolidation this should get used more now.
 // I have cleaned it up a little, but it could probably use more.  -Sayu

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -50,18 +50,14 @@
 		return 0
 	on = !on
 	update_brightness(user)
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
+	update_action_button_icons()
 	return 1
 
 /obj/item/device/flashlight/proc/turn_off_light(mob/bearer)
 	if(on)
 		on = 0
 		update_brightness(bearer)
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 		return 1
 	return 0
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -80,7 +80,7 @@ REAGENT SCANNER
 	var/mode = 1
 	var/hud_mode = 1
 
-/obj/item/device/healthanalyzer/attack(mob/living/M, mob/living/user)
+/obj/item/device/healthanalyzer/attack(mob/living/carbon/M, mob/living/user)
 	var/dat = ""
 	if(( (CLUMSY in user.mutations) || user.getBrainLoss() >= 60) && prob(50))
 		to_chat(user, "<span class='warning'>You try to analyze the floor's vitals!</span>")

--- a/code/game/objects/items/implants/implantneurostim.dm
+++ b/code/game/objects/items/implants/implantneurostim.dm
@@ -39,27 +39,27 @@
 
 	last_activated = world.time
 
-	if(istype(imp_in, /mob/living/))
-		var/mob/living/M = imp_in
+	if(istype(imp_in, /mob/living/carbon))
+		var/mob/living/carbon/C = imp_in
 		if(accidental) //was triggered by random chance or EMP
-			playsound(M, 'sound/machines/buzz-two.ogg', 60, 1)
+			playsound(C, 'sound/machines/buzz-two.ogg', 60, 1)
 			imp_in.visible_message("<span class='warning'>Something buzzes inside [imp_in][part ? "'s [part.display_name]" : ""].</span>")
 		else
-			playsound(M, 'sound/machines/twobeep.ogg', 60, 1)
+			playsound(C, 'sound/machines/twobeep.ogg', 60, 1)
 			imp_in.visible_message("<span class='warning'>Something beeps inside [imp_in][part ? "'s [part.display_name]" : ""].</span>")
 		sleep(10)
-		playsound(M, 'sound/effects/sparks2.ogg', 60, 1)
+		playsound(C, 'sound/effects/sparks2.ogg', 60, 1)
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(2, 1, src)
 		s.start()
 		sleep(5)
 
-		M.visible_message("<span class='danger'>[M] convulses in pain!</span>", "<span class='danger'>Excruciating pain shoots through [part ? "your [part.display_name]" : "you"]!</span>")
-		M.flash_eyes(1, TRUE)
-		M.stunned += 10
-		M.KnockDown(10)
-		M.apply_damage(100, HALLOSS, part)
-		M.apply_damage(5, BURN, part, 0, 0, 0, src)
+		C.visible_message("<span class='danger'>[C] convulses in pain!</span>", "<span class='danger'>Excruciating pain shoots through [part ? "your [part.display_name]" : "you"]!</span>")
+		C.flash_eyes(1, TRUE)
+		C.stunned += 10
+		C.KnockDown(10)
+		C.apply_damage(100, HALLOSS, part)
+		C.apply_damage(5, BURN, part, 0, 0, 0, src)
 
 	else
 		playsound(src, 'sound/machines/twobeep.ogg', 60, 1)

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -41,9 +41,7 @@
 		var/mob/M = usr
 		M.update_inv_back()
 
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
+	update_action_button_icons()
 
 /obj/item/tank/jetpack/proc/allow_thrust(num, mob/living/user)
 	if(!(src.on))

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -42,9 +42,7 @@
 				H.update_tint()
 				H.update_sight()
 
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 
 
 
@@ -189,9 +187,7 @@
 
 		update_clothing_icon()
 
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 
 
 /obj/item/clothing/glasses/welding/superior

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -26,9 +26,7 @@
 			var/mob/M = loc
 			M.update_inv_head()
 
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 
 	pickup(mob/user)
 		if(on)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -67,9 +67,7 @@
 
 		update_clothing_icon()	//so our mob-overlays update
 
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 
 /*
  * Cakehat

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -22,9 +22,7 @@
 			to_chat(user, "You enable the mag-pulse traction system.")
 		user.update_inv_shoes()	//so our mob-overlays update
 
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 
 
 	examine(mob/user)

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -40,9 +40,7 @@
 			var/mob/living/carbon/human/H = user
 			H.update_inv_head()
 
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 
 	pickup(mob/user)
 		if(on)

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -189,9 +189,7 @@ var/list/squad_colors = list(rgb(230,25,25), rgb(255,195,45), rgb(200,100,200), 
 	playsound(src,'sound/machines/click.ogg', 15, 1)
 	update_icon(user)
 
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
+	update_action_button_icons()
 
 
 /obj/item/clothing/suit/storage/marine/MP
@@ -599,9 +597,7 @@ var/list/squad_colors = list(rgb(230,25,25), rgb(255,195,45), rgb(200,100,200), 
 	playsound(src,'sound/machines/click.ogg', 15, 1)
 	update_icon(user)
 
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
+	update_action_button_icons()
 
 
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -20,3 +20,7 @@
 
 	var/rotate_on_lying = 1
 
+	var/halloss = 0		//Hallucination damage. 'Fake' damage obtained through hallucinating or the holodeck. Sleeping should cause it to wear off.
+
+	var/traumatic_shock = 0
+	var/shock_stage = 0

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -1,12 +1,12 @@
 /mob/living/carbon/proc/getHalLoss()
 	return halloss
 
-/mob/living/carbon/proc/adjustHalLoss(var/amount)
+/mob/living/carbon/adjustHalLoss(amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
 	halloss = CLAMP(halloss+amount,0,maxHealth*2)
 
-/mob/living/carbon/proc/setHalLoss(var/amount)
+/mob/living/carbon/proc/setHalLoss(amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
 	halloss = amount
@@ -14,12 +14,12 @@
 /mob/living/carbon/proc/getTraumatic_Shock()
 	return traumatic_shock
 
-/mob/living/carbon/proc/adjustTraumatic_Shock(var/amount)
+/mob/living/carbon/proc/adjustTraumatic_Shock(amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
 	traumatic_shock = CLAMP(traumatic_shock+amount,0,maxHealth*2)
 
-/mob/living/carbon/proc/setTraumatic_Shock(var/amount)
+/mob/living/carbon/proc/setTraumatic_Shock(amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
 	traumatic_shock = amount
@@ -27,12 +27,12 @@
 /mob/living/carbon/proc/getShock_Stage()
 	return shock_stage
 
-/mob/living/carbon/proc/adjustShock_Stage(var/amount)
+/mob/living/carbon/proc/adjustShock_Stage(amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
 	shock_stage = CLAMP(shock_stage+amount,0,maxHealth*2)
 
-/mob/living/carbon/proc/setShock_Stage(var/amount)
+/mob/living/carbon/proc/setShock_Stage(amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
 	shock_stage = amount

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -1,5 +1,5 @@
 /mob/living/var/traumatic_shock = 0
-/mob/living/carbon/var/shock_stage = 0
+/mob/living/var/shock_stage = 0
 
 // proc to find out in how much pain the mob is at the moment
 /mob/living/carbon/proc/updateshock()

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -1,5 +1,41 @@
-/mob/living/var/traumatic_shock = 0
-/mob/living/var/shock_stage = 0
+/mob/living/carbon/proc/getHalLoss()
+	return halloss
+
+/mob/living/carbon/proc/adjustHalLoss(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	halloss = CLAMP(halloss+amount,0,maxHealth*2)
+
+/mob/living/carbon/proc/setHalLoss(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	halloss = amount
+
+/mob/living/carbon/proc/getTraumatic_Shock()
+	return traumatic_shock
+
+/mob/living/carbon/proc/adjustTraumatic_Shock(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	traumatic_shock = CLAMP(traumatic_shock+amount,0,maxHealth*2)
+
+/mob/living/carbon/proc/setTraumatic_Shock(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	traumatic_shock = amount
+
+/mob/living/carbon/proc/getShock_Stage()
+	return shock_stage
+
+/mob/living/carbon/proc/adjustShock_Stage(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	shock_stage = CLAMP(shock_stage+amount,0,maxHealth*2)
+
+/mob/living/carbon/proc/setShock_Stage(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	shock_stage = amount
 
 // proc to find out in how much pain the mob is at the moment
 /mob/living/carbon/proc/updateshock()

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Boiler.dm
@@ -139,9 +139,7 @@
 		spawn(bomb_delay) //20 seconds cooldown.
 			bomb_cooldown = 0
 			to_chat(src, "<span class='notice'>You feel your toxin glands swell. You are able to bombard an area again.</span>")
-			for(var/X in actions)
-				var/datum/action/A = X
-				A.update_button_icon()
+			update_action_button_icons()
 		return
 	else
 		bomb_cooldown = 0
@@ -193,9 +191,7 @@
 		spawn(acid_delay) //12 second cooldown.
 			acid_cooldown = 0
 			to_chat(src, "<span class='warning'>You feel your acid glands refill. You can spray <B>acid</b> again.</span>")
-			for(var/X in actions)
-				var/datum/action/A = X
-				A.update_button_icon()
+			update_action_button_icons()
 	else
 		to_chat(src, "<span class='warning'>You see nothing to spit at!</span>")
 

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Carrier.dm
@@ -118,18 +118,14 @@
 
 	if(!threw_a_hugger)
 		threw_a_hugger = 1
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 		drop_inv_item_on_ground(F)
 		F.throw_at(T, 4, throwspeed)
 		visible_message("<span class='xenowarning'>\The [src] throws something towards \the [T]!</span>", \
 		"<span class='xenowarning'>You throw a facehugger towards \the [T]!</span>")
 		spawn(hugger_delay)
 			threw_a_hugger = 0
-			for(var/X in actions)
-				var/datum/action/A = X
-				A.update_button_icon()
+			update_action_button_icons()
 
 
 

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Predalien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Predalien.dm
@@ -130,7 +130,7 @@ Your health meter will not regenerate normally, so kill and die for the hive!</s
 			playsound(loc, 'sound/weapons/slice.ogg', 25)
 			emote("growl")
 			var/to_heal = max(1, 5 - (0.2 * (health < maxHealth ? butchered_sum++ : butchered_sum)))//So we do not heal multiple times due to the inline proc below.
-			XENO_HEAL_WOUNDS(isYautja(H)? 15 : to_heal) //Predators give far better healing.
+			heal_wounds(isYautja(H)? 15 : to_heal) //Predators give far better healing.
 		else
 			visible_message("<span class='danger'>[src] slices and dices [H]'s body like a ragdoll!</span>",
 			"<span class='xenodanger'>You fly into a frenzy and butcher [H]'s body!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Queen.dm
@@ -354,23 +354,23 @@
 			else
 				shake_camera(M, 30, 1) //50 deciseconds, SORRY 5 seconds was way too long. 3 seconds now
 
-	for(var/mob/living/carbon/human/M in oview(7, src))
-		var/dist = get_dist(src,M)
-		var/reduction = max(1 - 0.1 * M.protection_aura, 0) //Hold orders will reduce the Halloss; 10% per rank.
+	for(var/mob/living/carbon/human/H in oview(7, src))
+		var/dist = get_dist(src,H)
+		var/reduction = max(1 - 0.1 * H.protection_aura, 0) //Hold orders will reduce the Halloss; 10% per rank.
 		var/halloss_damage = (max(0,140 - dist * 10)) * reduction //Max 130 beside Queen, 70 at the edge
 		var/stun_duration = max(0,1.1 - dist * 0.1) * reduction //Max 1 beside Queen, 0.4 at the edge.
 
 		if(dist < 8)
-			to_chat(M, "<span class='danger'>An ear-splitting guttural roar tears through your mind and makes your world convulse!</span>")
-			M.druggy += 3 //Perception distorting effects of the psychic scream
-			M.stunned += stun_duration
-			M.KnockDown(stun_duration)
-			M.apply_damage(halloss_damage, HALLOSS)
-			if(!M.ear_deaf)
-				M.ear_deaf += stun_duration * 20  //Deafens them temporarily
+			to_chat(H, "<span class='danger'>An ear-splitting guttural roar tears through your mind and makes your world convulse!</span>")
+			H.druggy += 3 //Perception distorting effects of the psychic scream
+			H.stunned += stun_duration
+			H.KnockDown(stun_duration)
+			H.apply_damage(halloss_damage, HALLOSS)
+			if(!H.ear_deaf)
+				H.ear_deaf += stun_duration * 20  //Deafens them temporarily
 			spawn(31)
-				M.druggy += stun_duration * 10 //Perception distorting effects of the psychic scream
-				shake_camera(M, stun_duration * 10, 0.75) //Perception distorting effects of the psychic scream
+				H.druggy += stun_duration * 10 //Perception distorting effects of the psychic scream
+				shake_camera(H, stun_duration * 10, 0.75) //Perception distorting effects of the psychic scream
 
 /mob/living/carbon/Xenomorph/Queen/proc/queen_gut(atom/A)
 

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Ravager.dm
@@ -69,9 +69,7 @@
 	spawn(CHARGECOOLDOWN)
 		usedPounce = 0
 		to_chat(src, "<span class='notice'>Your exoskeleton quivers as you get ready to charge again.</span>")
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 
 
 //Chance of insta limb amputation after a melee attack.

--- a/code/modules/mob/living/carbon/xenomorph/Castes/Warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Castes/Warrior.dm
@@ -97,9 +97,7 @@
 		spawn(lunge_cooldown)
 			used_lunge = 0
 			to_chat(src, "<span class='notice'>You get ready to lunge again.</span>")
-			for(var/X in actions)
-				var/datum/action/act = X
-				act.update_button_icon()
+			update_action_button_icons()
 
 /mob/living/carbon/Xenomorph/Warrior/hitby(atom/movable/AM as mob|obj,var/speed = 5)
 	if(ishuman(AM))

--- a/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Facehuggers.dm
@@ -62,31 +62,34 @@
 
 //Can be picked up by aliens
 /obj/item/clothing/mask/facehugger/attack_paw(user as mob)
-	attack_hand(user)
-
-/obj/item/clothing/mask/facehugger/attack_hand(user as mob)
-
-	if((stat == CONSCIOUS && !sterile))
-		if(CanHug(user))
-			Attach(user) //If we're conscious, don't let them pick us up even if this fails. Just return.
-			return
-	if(!isXeno(user) && stat != DEAD)
-		return
-
-	return ..()
+	if(isXeno(user))
+		attack_alien(user)
+	else
+		attack_hand(user)
 
 //Deal with picking up facehuggers. "attack_alien" is the universal 'xenos click something while unarmed' proc.
 /obj/item/clothing/mask/facehugger/attack_alien(mob/living/carbon/Xenomorph/user)
-
 	if(user.hivenumber != hivenumber)
 		user.animation_attack_on(src)
 		user.visible_message("<span class='xenowarning'>[user] crushes \the [src]","<span class='xenowarning'>You crush \the [src]")
 		Die()
 		return
+	else
+		attack_hand(user)
 
-	switch(user.caste)
-		if("Queen","Drone","Hivelord","Carrier")
-			attack_hand(user)//Not a carrier, or already full? Just pick it up.
+/obj/item/clothing/mask/facehugger/attack_hand(user as mob)
+	if(isXeno(user))
+		var/mob/living/carbon/Xenomorph/X = user
+		switch(X.caste)
+			if("Queen","Drone","Hivelord","Carrier")
+				return ..() // These can pick up huggers.
+			else
+				return FALSE // The rest can't.
+	if(stat == DEAD || sterile)
+		return ..() // Dead or sterile (lamarr) can be picked.
+	else if(stat == CONSCIOUS && CanHug(user)) // If you try to take a healthy one it will try to hug you.
+		Attach(user)
+	return FALSE // Else you can't pick.
 
 /obj/item/clothing/mask/facehugger/attack(mob/M, mob/user)
 	if(CanHug(M))

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -45,9 +45,7 @@
 	spawn(pounce_delay)
 		usedPounce = 0
 		to_chat(src, "<span class='notice'>You get ready to pounce again.</span>")
-		for(var/X in actions)
-			var/datum/action/A = X
-			A.update_button_icon()
+		update_action_button_icons()
 
 	return TRUE
 
@@ -297,9 +295,7 @@
 	spawn(fling_cooldown)
 		used_fling = FALSE
 		to_chat(src, "<span class='notice'>You gather enough strength to fling something again.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 /mob/living/carbon/Xenomorph/proc/punch(var/mob/living/M)
 
@@ -381,9 +377,7 @@
 	spawn(punch_cooldown)
 		used_punch = FALSE
 		to_chat(src, "<span class='notice'>You gather enough strength to punch again.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 /mob/living/carbon/Xenomorph/proc/lunge(atom/A)
 
@@ -419,9 +413,7 @@
 	spawn(lunge_cooldown)
 		used_lunge = FALSE
 		to_chat(src, "<span class='notice'>You get ready to lunge again.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 	return TRUE
 
@@ -522,9 +514,7 @@
 	spawn(toggle_agility_cooldown)
 		used_toggle_agility = FALSE
 		to_chat(src, "<span class='notice'>You can [agility ? "raise yourself back up" : "lower yourself back down"] again.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 
 // Defender Headbutt
@@ -614,9 +604,7 @@
 	spawn(headbutt_cooldown)
 		used_headbutt = 0
 		to_chat(src, "<span class='notice'>You gather enough strength to headbutt again.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 
 // Defender Tail Sweep
@@ -678,9 +666,7 @@
 	spawn(tail_sweep_cooldown)
 		used_tail_sweep = FALSE
 		to_chat(src, "<span class='notice'>You gather enough strength to tail sweep again.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 
 // Defender Crest Defense
@@ -727,9 +713,7 @@
 	spawn(crest_defense_cooldown)
 		used_crest_defense = FALSE
 		to_chat(src, "<span class='notice'>You can [crest_defense ? "raise" : "lower"] your crest.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 
 // Defender Fortify
@@ -784,9 +768,7 @@
 	spawn(fortify_cooldown)
 		used_fortify = FALSE
 		to_chat(src, "<span class='notice'>You can [fortify ? "stand up" : "fortify"] again.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 
 /* WIP Burrower stuff
@@ -840,9 +822,7 @@
 	spawn(burrow_cooldown)
 		used_burrow = 0
 		to_chat(src, "<span class='notice'>You can now surface or tunnel.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 
 
 /mob/living/carbon/Xenomorph/proc/tunnel(var/turf/T)
@@ -887,9 +867,7 @@
 	spawn(tunnel_cooldown)
 		used_tunnel = 0
 		to_chat(src, "<span class='notice'>You can now tunnel while burrowed.</span>")
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()
 */
 
 // Vent Crawl
@@ -995,9 +973,7 @@
 	switch(message)
 		if("spit")
 			to_chat(src, "<span class='notice'>You feel your neurotoxin glands swell with ichor. You can spit again.</span>")
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
+	update_action_button_icons()
 
 
 
@@ -1485,6 +1461,4 @@
 		savage_used = FALSE
 		to_chat(src, "<span class='xenowarning'><b>You can now savage your victims again.</b></span>")
 		playsound(src, "xeno_newlarva", 100, 0, 1)
-		for(var/X in actions)
-			var/datum/action/act = X
-			act.update_button_icon()
+		update_action_button_icons()

--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -335,7 +335,7 @@
 	playsound(M, S, 50, 1)
 
 	if(!ishuman(M))
-		apply_damage(damage, BRUTE, target_zone, armor_block) //If we're not a humie, just apply brute.
+		M.apply_damage(damage, BRUTE, target_zone, armor_block) //If we're not a humie, just apply brute.
 	else
 		var/mob/living/carbon/human/H = M
 
@@ -370,7 +370,7 @@
 			L.take_damage(damage, 0, 0, 0, null, null, null, armor_block)
 			if(prob(fracture_chance))
 				L.fracture()
-	apply_damage(damage, HALLOSS) //Armor penetrating halloss also applies.
+		H.apply_damage(damage, HALLOSS) //Armor penetrating halloss also applies.
 	shake_camera(M, 2, 1)
 	step_away(M, src, 2)
 

--- a/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoProcs.dm
@@ -113,15 +113,11 @@
 
 /mob/living/carbon/Xenomorph/proc/use_plasma(value)
 	plasma_stored = max(plasma_stored - value, 0)
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
+	update_action_button_icons()
 
 /mob/living/carbon/Xenomorph/proc/gain_plasma(value)
 	plasma_stored = min(plasma_stored + value, plasma_max)
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
+	update_action_button_icons()
 
 
 

--- a/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Xenomorph.dm
@@ -52,6 +52,7 @@
 	hud_possible = list(HEALTH_HUD_XENO, PLASMA_HUD, PHEROMONE_HUD,QUEEN_OVERWATCH_HUD)
 	unacidable = TRUE
 	var/hivenumber = XENO_HIVE_NORMAL
+	var/list/overlays_standing[X_TOTAL_LAYERS]
 
 
 /mob/living/carbon/Xenomorph/New()

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -109,10 +109,10 @@
 	updatehealth()
 	return TRUE
 
-/mob/living/carbon/Xenomorph/adjustBruteLoss(var/amount)
+/mob/living/carbon/Xenomorph/adjustBruteLoss(amount)
 	bruteloss = CLAMP(bruteloss + amount, 0, maxHealth - crit_health)
 
-/mob/living/carbon/Xenomorph/adjustFireLoss(var/amount)
+/mob/living/carbon/Xenomorph/adjustFireLoss(amount)
 	fireloss = CLAMP(fireloss + amount, 0, maxHealth - crit_health)
 
 /mob/living/carbon/Xenomorph/proc/check_blood_splash(damage = 0, damtype = BRUTE, chancemod = 0, radius = 1)

--- a/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/damage_procs.dm
@@ -79,7 +79,8 @@
 
 
 /mob/living/carbon/Xenomorph/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, blocked = 0, used_weapon = null, sharp = 0, edge = 0)
-	if(!damage) return
+	if(damage <= 0)
+		return FALSE
 
 	//We still want to check for blood splash before we get to the damage application.
 	var/chancemod = 0
@@ -93,13 +94,11 @@
 	if(damage > 12) //Light damage won't splash.
 		check_blood_splash(damage, damagetype, chancemod)
 
-	if(stat == DEAD) return
+	if(stat == DEAD)
+		return FALSE
 
-	if(warding_aura && damage > 0) //Damage reduction. Every half point of warding decreases damage by 2.5 %. Maximum is 25 % at 5 pheromone strength.
-		damage = round(damage * ((100 - (warding_aura * 5)) / 100))
-
-	if(def_zone == "head" || def_zone == "eyes" || def_zone == "mouth") //Little more damage vs the head
-		damage = round(damage * 8 / 7)
+	if(warding_aura) //Damage reduction. Every half point of warding decreases damage by 2.5 %. Maximum is 25 % at 5 pheromone strength.
+		damage = round(damage * (1 - (warding_aura * 0.05) ) )
 
 	switch(damagetype)
 		if(BRUTE)
@@ -108,13 +107,20 @@
 			adjustFireLoss(damage)
 
 	updatehealth()
-	return 1
+	return TRUE
+
+/mob/living/carbon/Xenomorph/adjustBruteLoss(var/amount)
+	bruteloss = CLAMP(bruteloss + amount, 0, maxHealth - crit_health)
+
+/mob/living/carbon/Xenomorph/adjustFireLoss(var/amount)
+	fireloss = CLAMP(fireloss + amount, 0, maxHealth - crit_health)
 
 /mob/living/carbon/Xenomorph/proc/check_blood_splash(damage = 0, damtype = BRUTE, chancemod = 0, radius = 1)
 	if(!damage)
-		return 0
+		return FALSE
 	var/chance = 20 //base chance
-	if(damtype == BRUTE) chance += 5
+	if(damtype == BRUTE)
+		chance += 5
 	chance += chancemod + (damage * 0.33)
 	var/turf/T = loc
 	if(!T || !istype(T))

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -1,14 +1,7 @@
-/*Heal 1/70th of your max health in brute per tick. 1 as a bonus, to help smaller pools.
-Additionally, recovery pheromones mutiply this base healing, up to 2.5 times faster at level 5
-Modified via m, to multiply the number of wounds healed.
-Heal from fire slower
-Make sure their actual health updates immediately.*/
-
-#define XENO_HEAL_WOUNDS(m) \
-adjustBruteLoss(-((maxHealth / 60) + 0.5 + (maxHealth / 60) * recovery_aura/2)*(m)); \
-adjustFireLoss(-(maxHealth / 70 + 0.5 + (maxHealth / 70) * recovery_aura/2)*(m))
-
 #define DEBUG_XENO_LIFE	0
+#define XENO_RESTING_HEAL 1
+#define XENO_STANDING_HEAL 0.2
+#define XENO_CRIT_DAMAGE 5
 
 /mob/living/carbon/Xenomorph/Life()
 
@@ -45,7 +38,7 @@ adjustFireLoss(-(maxHealth / 70 + 0.5 + (maxHealth / 70) * recovery_aura/2)*(m))
 	if(stat == DEAD)
 		return
 
-	if(health < crit_health)
+	if(health <= crit_health)
 		if(prob(gib_chance + 0.5*(crit_health - health)))
 			gib()
 		else
@@ -101,17 +94,39 @@ adjustFireLoss(-(maxHealth / 70 + 0.5 + (maxHealth / 70) * recovery_aura/2)*(m))
 		adjustFireLoss(fire_stacks + 3)
 
 /mob/living/carbon/Xenomorph/proc/handle_living_health_updates()
-	var/turf/T = loc
-	if(!T || !istype(T) || hardcore)
+	if(health >= maxHealth || hardcore) //no damage, don't bother
+		updatehealth()
 		return
-	if(health < maxHealth && (locate(/obj/effect/alien/weeds) in T) || innate_healing)
-		var/datum/hive_status/hive = hive_datum[hivenumber]
-		if(hive.living_xeno_queen.loc.z == loc.z || !hive.living_xeno_queen || innate_healing)
-			if(lying || resting)
-				XENO_HEAL_WOUNDS(1)
-			else
-				XENO_HEAL_WOUNDS(0.33) //Major healing nerf if standing
+	var/turf/T = loc
+	if(!T || !istype(T)) //where are we?
+		return
+	if(innate_healing) //Larvas regenerate fast anywhere as long as not in crit.
+		if(!(locate(/obj/effect/alien/weeds) in T) && health <= 0)
+			adjustBruteLoss(XENO_CRIT_DAMAGE)
+		else
+			heal_wounds(XENO_RESTING_HEAL)
+		updatehealth()
+		return
+	var/datum/hive_status/hive = hive_datum[hivenumber]
+	if(hive.living_xeno_queen && hive.living_xeno_queen.loc.z != loc.z) //if there is a queen, it must be in the same z-level
+		updatehealth()
+		return
+	if(locate(/obj/effect/alien/weeds) in T) //We regenerate on weeds.
+		if(lying || resting)
+			heal_wounds(XENO_RESTING_HEAL)
+		else
+			heal_wounds(XENO_STANDING_HEAL) //Major healing nerf if standing.
+	else if(health <= 0)
+		adjustBruteLoss(XENO_CRIT_DAMAGE) //Crit and no weeds makes us bleed.
 	updatehealth()
+
+/mob/living/carbon/Xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL)
+	var/amount = (1 + (maxHealth * 0.02) ) // 1 damage + 2% max health
+	if(recovery_aura)
+		amount += recovery_aura * maxHealth * 0.01 // +1% max health per recovery level, up to +5%
+	amount *= multiplier
+	adjustBruteLoss(-amount)
+	adjustFireLoss(-amount)
 
 /mob/living/carbon/Xenomorph/Xenoborg/handle_living_health_updates()
 	updatehealth()
@@ -369,9 +384,7 @@ adjustFireLoss(-(maxHealth / 70 + 0.5 + (maxHealth / 70) * recovery_aura/2)*(m))
 /mob/living/carbon/Xenomorph/updatehealth()
 	if(status_flags & GODMODE)
 		return
-
 	health = maxHealth - getFireLoss() - getBruteLoss() //Xenos can only take brute and fire damage.
-
 	med_hud_set_health()
 	update_stat()
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -29,6 +29,7 @@
 	handle_aura_receiver()
 	handle_living_health_updates()
 	handle_living_plasma_updates()
+	update_action_button_icons()
 	update_icons()
 
 /mob/living/carbon/Xenomorph/update_stat()
@@ -153,10 +154,6 @@
 		if(current_aura)
 			current_aura = null
 			to_chat(src, "<span class='warning'>You have ran out of plasma and stopped emitting pheromones.</span>")
-
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
 
 	hud_set_plasma() //update plasma amount on the plasma mob_hud
 

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -96,7 +96,7 @@
 
 /mob/living/carbon/Xenomorph/proc/handle_living_health_updates()
 	if(health >= maxHealth || hardcore) //no damage, don't bother
-		updatehealth()
+		updatehealth() //Update health-related stats, like health itself (using brute and fireloss), health HUD and status.
 		return
 	var/turf/T = loc
 	if(!T || !istype(T)) //where are we?

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -37,11 +37,6 @@
 			icon_state = "[caste] Walking"
 	update_fire() //the fire overlay depends on the xeno's stance, so we must update it.
 
-/mob/living/carbon/Xenomorph/proc/update_action_button_icons()
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.update_button_icon()
-
 /mob/living/carbon/Xenomorph/regenerate_icons()
 	..()
 	if(monkeyizing)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -12,9 +12,6 @@
 #define X_TOTAL_LAYERS			7
 /////////////////////////////////
 
-/mob/living/carbon/Xenomorph
-	var/list/overlays_standing[X_TOTAL_LAYERS]
-
 /mob/living/carbon/Xenomorph/apply_overlay(cache_index)
 	var/image/I = overlays_standing[cache_index]
 	if(I)
@@ -134,12 +131,3 @@
 /mob/living/carbon/Xenomorph/update_transform()
 	..()
 	return update_icons()
-
-//Xeno Overlays Indexes//////////
-#undef X_HEAD_LAYER
-#undef X_SUIT_LAYER
-#undef X_L_HAND_LAYER
-#undef X_R_HAND_LAYER
-#undef X_LEGCUFF_LAYER
-#undef X_FIRE_LAYER
-#undef X_TOTAL_LAYERS

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -35,8 +35,12 @@
 			icon_state = "[caste] Running"
 		else
 			icon_state = "[caste] Walking"
-
 	update_fire() //the fire overlay depends on the xeno's stance, so we must update it.
+
+/mob/living/carbon/Xenomorph/proc/update_action_button_icons()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.update_button_icon()
 
 /mob/living/carbon/Xenomorph/regenerate_icons()
 	..()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -29,21 +29,31 @@
 		if(CLONE)
 			adjustCloneLoss(damage)
 		if(HALLOSS)
-			adjustHalLoss(damage)
+			var/mob/living/carbon/C = src
+			if(istype(C))
+				C.adjustHalLoss(damage)
 	updatehealth()
-	return 1
+	return TRUE
 
 
 /mob/living/proc/apply_damages(var/brute = 0, var/burn = 0, var/tox = 0, var/oxy = 0, var/clone = 0, var/halloss = 0, var/def_zone = null, var/blocked = 0)
 	if(blocked >= 1) //Complete negation/100% reduction
-		return 0
-	if(brute)	apply_damage(brute, BRUTE, def_zone, blocked)
-	if(burn)	apply_damage(burn, BURN, def_zone, blocked)
-	if(tox)		apply_damage(tox, TOX, def_zone, blocked)
-	if(oxy)		apply_damage(oxy, OXY, def_zone, blocked)
-	if(clone)	apply_damage(clone, CLONE, def_zone, blocked)
-	if(halloss) apply_damage(halloss, HALLOSS, def_zone, blocked)
-	return 1
+		return FALSE
+	if(brute)
+		apply_damage(brute, BRUTE, def_zone, blocked)
+	if(burn)
+		apply_damage(burn, BURN, def_zone, blocked)
+	if(tox)
+		apply_damage(tox, TOX, def_zone, blocked)
+	if(oxy)
+		apply_damage(oxy, OXY, def_zone, blocked)
+	if(clone)
+		apply_damage(clone, CLONE, def_zone, blocked)
+	if(halloss)
+		var/mob/living/carbon/C = src
+		if(istype(C))
+			C.apply_damage(halloss, HALLOSS, def_zone, blocked)
+	return TRUE
 
 
 
@@ -57,7 +67,9 @@
 		if(PARALYZE)
 			KnockOut(effect/(blocked+1))
 		if(AGONY)
-			halloss += effect // Useful for objects that cause "subdual" damage. PAIN!
+			var/mob/living/carbon/C = src
+			if(istype(C))
+				C.halloss += effect // Useful for objects that cause "subdual" damage. PAIN!
 		if(IRRADIATE)
 			var/rad_protection = getarmor(null, "rad")/100
 			radiation += max((1-rad_protection)*effect/(blocked+1),0)//Rads auto check armor

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -29,9 +29,7 @@
 		if(CLONE)
 			adjustCloneLoss(damage)
 		if(HALLOSS)
-			var/mob/living/carbon/C = src
-			if(istype(C))
-				C.adjustHalLoss(damage)
+			adjustHalLoss(damage)
 	updatehealth()
 	return TRUE
 
@@ -50,9 +48,7 @@
 	if(clone)
 		apply_damage(clone, CLONE, def_zone, blocked)
 	if(halloss)
-		var/mob/living/carbon/C = src
-		if(istype(C))
-			C.apply_damage(halloss, HALLOSS, def_zone, blocked)
+		apply_damage(halloss, HALLOSS, def_zone, blocked)
 	return TRUE
 
 
@@ -67,9 +63,7 @@
 		if(PARALYZE)
 			KnockOut(effect/(blocked+1))
 		if(AGONY)
-			var/mob/living/carbon/C = src
-			if(istype(C))
-				C.halloss += effect // Useful for objects that cause "subdual" damage. PAIN!
+			adjustHalLoss(effect/blocked+1)
 		if(IRRADIATE)
 			var/rad_protection = getarmor(null, "rad")/100
 			radiation += max((1-rad_protection)*effect/(blocked+1),0)//Rads auto check armor

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -88,8 +88,7 @@
 /mob/living/proc/updatehealth()
 	if(status_flags & GODMODE)
 		return
-
-	health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - halloss
+	health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss()
 	update_stat()
 
 /mob/living/New()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -573,3 +573,8 @@ below 100 is not dizzy
 	if(client)
 		client.pixel_x = 0
 		client.pixel_y = 0
+
+/mob/living/proc/update_action_button_icons()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.update_button_icon()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -28,7 +28,7 @@
 		apply_effect(STUTTER, stun_amount)
 		apply_effect(EYE_BLUR, stun_amount)
 
-	if (agony_amount)
+	if(agony_amount && iscarbon(src))
 		apply_damage(agony_amount, HALLOSS, def_zone, 0, used_weapon)
 		apply_effect(STUTTER, agony_amount/10)
 		apply_effect(EYE_BLUR, agony_amount/10)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -28,7 +28,7 @@
 		apply_effect(STUTTER, stun_amount)
 		apply_effect(EYE_BLUR, stun_amount)
 
-	if(agony_amount && iscarbon(src))
+	if(agony_amount)
 		apply_damage(agony_amount, HALLOSS, def_zone, 0, used_weapon)
 		apply_effect(STUTTER, agony_amount/10)
 		apply_effect(EYE_BLUR, agony_amount/10)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -14,7 +14,6 @@
 	var/fireloss = 0.0	//Burn damage caused by being way too hot, too cold or burnt.
 	var/cloneloss = 0	//Damage caused by being cloned or ejected from the cloner early
 	var/brainloss = 0	//'Retardation' damage caused by someone hitting you in the head with a bible or being infected with brainrot.
-	var/halloss = 0		//Hallucination damage. 'Fake' damage obtained through hallucinating or the holodeck. Sleeping should cause it to wear off.
 
 	var/confused = 0	//Makes the mob move in random directions.
 	var/is_dizzy = FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -76,3 +76,5 @@
 	var/reagent_pain_modifier = 0 //same as above, except can potentially mask damage
 
 	var/smokecloaked = FALSE //For the new Smoke Grenade
+
+	var/canEnterVentWith = "/obj/item/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0&/obj/item/verbs=0" // Vent crawling whitelisted items, whoo

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -6,70 +6,108 @@
 	return bruteloss
 
 /mob/living/proc/adjustBruteLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	bruteloss = min(max(bruteloss + amount, 0),(maxHealth*2))
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	bruteloss += amount
 
 /mob/living/proc/getOxyLoss()
 	return oxyloss
 
 /mob/living/proc/adjustOxyLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	oxyloss = min(max(oxyloss + amount, 0),(maxHealth*2))
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	oxyloss += amount
 
 /mob/living/proc/setOxyLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
 	oxyloss = amount
 
 /mob/living/proc/getToxLoss()
 	return toxloss
 
 /mob/living/proc/adjustToxLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	toxloss = min(max(toxloss + amount, 0),(maxHealth*2))
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	toxloss += amount
 
 /mob/living/proc/setToxLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
 	toxloss = amount
 
 /mob/living/proc/getFireLoss()
 	return fireloss
 
 /mob/living/proc/adjustFireLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	fireloss = min(max(fireloss + amount, 0),(maxHealth*2))
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	fireloss += amount
 
 /mob/living/proc/getCloneLoss()
 	return cloneloss
 
 /mob/living/proc/adjustCloneLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	cloneloss = min(max(cloneloss + amount, 0),(maxHealth*2))
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	cloneloss += amount
 
 /mob/living/proc/setCloneLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
 	cloneloss = amount
 
 /mob/living/proc/getBrainLoss()
 	return brainloss
 
 /mob/living/proc/adjustBrainLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	brainloss = min(max(brainloss + amount, 0),(maxHealth*2))
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	brainloss += amount
 
 /mob/living/proc/setBrainLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
 	brainloss = amount
 
 /mob/living/proc/getHalLoss()
 	return halloss
 
 /mob/living/proc/adjustHalLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	halloss = min(max(halloss + amount, 0),(maxHealth*2))
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	halloss += amount
 
 /mob/living/proc/setHalLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
 	halloss = amount
+
+/mob/living/proc/getTraumatic_Shock()
+	return traumatic_shock
+
+/mob/living/proc/adjustTraumatic_Shock(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	traumatic_shock += amount
+
+/mob/living/proc/setTraumatic_Shock(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	traumatic_shock = amount
+
+/mob/living/proc/getShock_Stage()
+	return shock_stage
+
+/mob/living/proc/adjustShock_Stage(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	shock_stage += amount
+
+/mob/living/proc/setShock_Stage(var/amount)
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
+	shock_stage = amount
 
 /mob/living/proc/getMaxHealth()
 	return maxHealth
@@ -91,7 +129,8 @@
 
 // damage ONE limb, organ gets randomly selected from damaged ones.
 /mob/living/proc/take_limb_damage(var/brute, var/burn)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
 	adjustBruteLoss(brute)
 	adjustFireLoss(burn)
 	src.updatehealth()
@@ -104,7 +143,8 @@
 
 // damage MANY limbs, in random order
 /mob/living/proc/take_overall_damage(var/brute, var/burn, var/used_weapon = null)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)
+		return FALSE	//godmode
 	adjustBruteLoss(brute)
 	adjustFireLoss(burn)
 	src.updatehealth()
@@ -126,6 +166,8 @@
 	setCloneLoss(0)
 	setBrainLoss(0)
 	setHalLoss(0)
+	setTraumatic_Shock(0)
+	setShock_Stage(0)
 	SetKnockedout(0)
 	SetStunned(0)
 	SetKnockeddown(0)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -70,50 +70,12 @@
 		return FALSE	//godmode
 	brainloss = amount
 
-/mob/living/proc/getHalLoss()
-	return halloss
-
-/mob/living/proc/adjustHalLoss(var/amount)
-	if(status_flags & GODMODE)
-		return FALSE	//godmode
-	halloss = CLAMP(halloss+amount,0,maxHealth*2)
-
-/mob/living/proc/setHalLoss(var/amount)
-	if(status_flags & GODMODE)
-		return FALSE	//godmode
-	halloss = amount
-
-/mob/living/proc/getTraumatic_Shock()
-	return traumatic_shock
-
-/mob/living/proc/adjustTraumatic_Shock(var/amount)
-	if(status_flags & GODMODE)
-		return FALSE	//godmode
-	traumatic_shock = CLAMP(traumatic_shock+amount,0,maxHealth*2)
-
-/mob/living/proc/setTraumatic_Shock(var/amount)
-	if(status_flags & GODMODE)
-		return FALSE	//godmode
-	traumatic_shock = amount
-
-/mob/living/proc/getShock_Stage()
-	return shock_stage
-
-/mob/living/proc/adjustShock_Stage(var/amount)
-	if(status_flags & GODMODE)
-		return FALSE	//godmode
-	shock_stage = CLAMP(shock_stage+amount,0,maxHealth*2)
-
-/mob/living/proc/setShock_Stage(var/amount)
-	if(status_flags & GODMODE)
-		return FALSE	//godmode
-	shock_stage = amount
-
 /mob/living/proc/getMaxHealth()
 	return maxHealth
 
 /mob/living/proc/setMaxHealth(var/newMaxHealth)
 	maxHealth = newMaxHealth
+
 
 
 
@@ -164,9 +126,6 @@
 	setOxyLoss(0)
 	setCloneLoss(0)
 	setBrainLoss(0)
-	setHalLoss(0)
-	setTraumatic_Shock(0)
-	setShock_Stage(0)
 	SetKnockedout(0)
 	SetStunned(0)
 	SetKnockeddown(0)
@@ -205,6 +164,12 @@
 	med_hud_set_status()
 	med_hud_set_health()
 	reload_fullscreens()
+
+/mob/living/carbon/rejuvenate()
+	setHalLoss(0)
+	setTraumatic_Shock(0)
+	setShock_Stage(0)
+	return ..()
 
 /mob/living/carbon/human/rejuvenate()
 	restore_blood() //restore all of a human's blood

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -76,7 +76,8 @@
 /mob/living/proc/setMaxHealth(var/newMaxHealth)
 	maxHealth = newMaxHealth
 
-
+mob/living/proc/adjustHalLoss(amount) //This only makes sense for carbon.
+	return
 
 
 

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -8,7 +8,7 @@
 /mob/living/proc/adjustBruteLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	bruteloss += amount
+	bruteloss = CLAMP(bruteloss+amount,0,maxHealth*2)
 
 /mob/living/proc/getOxyLoss()
 	return oxyloss
@@ -16,7 +16,7 @@
 /mob/living/proc/adjustOxyLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	oxyloss += amount
+	oxyloss = CLAMP(oxyloss+amount,0,maxHealth*2)
 
 /mob/living/proc/setOxyLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -29,7 +29,7 @@
 /mob/living/proc/adjustToxLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	toxloss += amount
+	toxloss = CLAMP(toxloss+amount,0,maxHealth*2)
 
 /mob/living/proc/setToxLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -42,7 +42,7 @@
 /mob/living/proc/adjustFireLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	fireloss += amount
+	fireloss = CLAMP(fireloss+amount,0,maxHealth*2)
 
 /mob/living/proc/getCloneLoss()
 	return cloneloss
@@ -50,7 +50,7 @@
 /mob/living/proc/adjustCloneLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	cloneloss += amount
+	cloneloss = CLAMP(cloneloss+amount,0,maxHealth*2)
 
 /mob/living/proc/setCloneLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -63,7 +63,7 @@
 /mob/living/proc/adjustBrainLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	brainloss += amount
+	brainloss = CLAMP(brainloss+amount,0,maxHealth*2)
 
 /mob/living/proc/setBrainLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -76,7 +76,7 @@
 /mob/living/proc/adjustHalLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	halloss += amount
+	halloss = CLAMP(halloss+amount,0,maxHealth*2)
 
 /mob/living/proc/setHalLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -89,7 +89,7 @@
 /mob/living/proc/adjustTraumatic_Shock(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	traumatic_shock += amount
+	traumatic_shock = CLAMP(traumatic_shock+amount,0,maxHealth*2)
 
 /mob/living/proc/setTraumatic_Shock(var/amount)
 	if(status_flags & GODMODE)
@@ -102,7 +102,7 @@
 /mob/living/proc/adjustShock_Stage(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	shock_stage += amount
+	shock_stage = CLAMP(shock_stage+amount,0,maxHealth*2)
 
 /mob/living/proc/setShock_Stage(var/amount)
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -157,7 +157,6 @@
 /mob/living/proc/revive(keep_viruses)
 	rejuvenate()
 
-
 /mob/living/proc/rejuvenate()
 
 	// shut down various types of badness
@@ -187,15 +186,6 @@
 	setEarDamage(0, 0)
 	heal_overall_damage(getBruteLoss(), getFireLoss())
 
-	// restore all of a human's blood
-	if(ishuman(src))
-		var/mob/living/carbon/human/H = src
-		H.restore_blood()
-		H.reagents.clear_reagents() //and clear all reagents in them
-		H.undefibbable = FALSE
-		H.chestburst = 0
-		H.mutations.Remove(HUSK)
-
 	// fix all of our organs
 	restore_all_organs()
 
@@ -215,3 +205,17 @@
 	med_hud_set_status()
 	med_hud_set_health()
 	reload_fullscreens()
+
+/mob/living/carbon/human/rejuvenate()
+	restore_blood() //restore all of a human's blood
+	reagents.clear_reagents() //and clear all reagents in them
+	undefibbable = FALSE
+	chestburst = 0
+	mutations.Remove(HUSK)
+	return ..()
+
+/mob/living/carbon/Xenomorph/rejuvenate()
+	plasma_stored = plasma_max
+	stagger = 0
+	slowdown = 0
+	return ..()

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -36,7 +36,7 @@
 	user.visible_message("<span class='notice'> [user] has analyzed [M]'s components.","<span class='notice'> You have analyzed [M]'s components.")
 	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
 	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
-	user.show_message("\blue Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "fully disabled" : "[M.health - M.halloss]% functional"]")
+	user.show_message("\blue Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "fully disabled" : "[M.health]% functional"]")
 	user.show_message("\t Key: <font color='#FFA500'>Electronics</font>/<font color='red'>Brute</font>", 1)
 	user.show_message("\t Damage Specifics: <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>")
 	if(M.tod && M.stat == DEAD)

--- a/code/modules/reagents/chemistry_reagents/medical.dm
+++ b/code/modules/reagents/chemistry_reagents/medical.dm
@@ -684,71 +684,71 @@ datum/reagent/medicine/synaptizine/overdose_crit_process(mob/living/M, alien)
 	addiction_threshold = 0.4 // Adios Addiction Virus
 	taste_multi = 2
 
-/datum/reagent/medicine/ultrazine/on_mob_life(mob/living/M)
-	M.reagent_move_delay_modifier -= 10
+/datum/reagent/medicine/ultrazine/on_mob_life(mob/living/carbon/C)
+	C.reagent_move_delay_modifier -= 10
 	if(prob(50))
-		M.AdjustKnockeddown(-1)
-		M.AdjustStunned(-1)
-		M.AdjustKnockedout(-1)
-	M.adjustHalLoss(-2)
+		C.AdjustKnockeddown(-1)
+		C.AdjustStunned(-1)
+		C.AdjustKnockedout(-1)
+	C.adjustHalLoss(-2)
 	if(prob(2))
-		M.emote(pick("twitch","blink_r","shiver"))
-	..()
+		C.emote(pick("twitch","blink_r","shiver"))
+	return ..()
 
-/datum/reagent/medicine/ultrazine/addiction_act_stage1(mob/living/M, alien)
+/datum/reagent/medicine/ultrazine/addiction_act_stage1(mob/living/carbon/C, alien)
 	if(prob(10))
-		to_chat(M, "<span class='notice'>[pick("You could use another hit.", "More of that would be nice.", "Another dose would help.", "One more dose wouldn't hurt", "Why not take one more?")]</span>")
+		to_chat(C, "<span class='notice'>[pick("You could use another hit.", "More of that would be nice.", "Another dose would help.", "One more dose wouldn't hurt", "Why not take one more?")]</span>")
 	if(prob(5))
-		M.emote(pick("twitch","blink_r","shiver"))
-		M.adjustHalLoss(20)
+		C.emote(pick("twitch","blink_r","shiver"))
+		C.adjustHalLoss(20)
 	if(prob(20))
-		M.hallucination += 10
+		C.hallucination += 10
 	return
 
-/datum/reagent/medicine/ultrazine/addiction_act_stage2(mob/living/M, alien)
+/datum/reagent/medicine/ultrazine/addiction_act_stage2(mob/living/carbon/C, alien)
 	if(prob(10))
-		to_chat(M, "<span class='warning'>[pick("It's just not the same without it.", "You could use another hit.", "You should take another.", "Just one more.", "Looks like you need another one.")]</span>")
+		to_chat(C, "<span class='warning'>[pick("It's just not the same without it.", "You could use another hit.", "You should take another.", "Just one more.", "Looks like you need another one.")]</span>")
 	if(prob(5))
-		M.emote("me",1, pick("winces slightly.", "grimaces."))
-		M.adjustHalLoss(35)
-		M.Stun(2)
+		C.emote("me",1, pick("winces slightly.", "grimaces."))
+		C.adjustHalLoss(35)
+		C.Stun(2)
 	if(prob(20))
-		M.hallucination += 15
-		M.confused += 3
+		C.hallucination += 15
+		C.confused += 3
 	return
 
 
-/datum/reagent/medicine/ultrazine/addiction_act_stage3(mob/living/M, alien)
+/datum/reagent/medicine/ultrazine/addiction_act_stage3(mob/living/carbon/C, alien)
 	if(prob(10))
-		to_chat(M, "<span class='warning'>[pick("You need more.", "It's hard to go on like this.", "You want more. You need more.", "Just take another hit. Now.", "One more.")]</span>")
+		to_chat(C, "<span class='warning'>[pick("You need more.", "It's hard to go on like this.", "You want more. You need more.", "Just take another hit. Now.", "One more.")]</span>")
 	if(prob(5))
-		M.emote("me",1, pick("winces.", "grimaces.", "groans!"))
-		M.adjustHalLoss(50)
-		M.Stun(3)
+		C.emote("me",1, pick("winces.", "grimaces.", "groans!"))
+		C.adjustHalLoss(50)
+		C.Stun(3)
 	if(prob(20))
-		M.hallucination += 20
-		M.confused += 5
-		M.Dizzy(60)
-	M.adjustToxLoss(0.1)
-	M.adjustBrainLoss(0.1)
+		C.hallucination += 20
+		C.confused += 5
+		C.Dizzy(60)
+	C.adjustToxLoss(0.1)
+	C.adjustBrainLoss(0.1)
 	return
 
-/datum/reagent/medicine/ultrazine/addiction_act_stage4(mob/living/M, alien)
+/datum/reagent/medicine/ultrazine/addiction_act_stage4(mob/living/carbon/C, alien)
 	if(prob(10))
-		to_chat(M, "<span class='danger'>[pick("You need another dose, now. NOW.", "You can't stand it. You have to go back. You have to go back.", "You need more. YOU NEED MORE.", "MORE", "TAKE MORE.")]</span>")
+		to_chat(C, "<span class='danger'>[pick("You need another dose, now. NOW.", "You can't stand it. You have to go back. You have to go back.", "You need more. YOU NEED MORE.", "MORE", "TAKE MORE.")]</span>")
 	if(prob(5))
-		M.emote("me",1, pick("groans painfully!", "contorts with pain!"))
-		M.adjustHalLoss(65)
-		M.Stun(4)
-		M.do_jitter_animation(200)
+		C.emote("me",1, pick("groans painfully!", "contorts with pain!"))
+		C.adjustHalLoss(65)
+		C.Stun(4)
+		C.do_jitter_animation(200)
 	if(prob(20))
-		M.hallucination += 30
-		M.confused += 7
-		M.Dizzy(80)
-	M.adjustToxLoss(0.3)
-	M.adjustBrainLoss(0.1)
-	if(prob(15) && ishuman(M))
-		var/mob/living/carbon/human/H = M
+		C.hallucination += 30
+		C.confused += 7
+		C.Dizzy(80)
+	C.adjustToxLoss(0.3)
+	C.adjustBrainLoss(0.1)
+	if(prob(15) && ishuman(C))
+		var/mob/living/carbon/human/H = C
 		var/affected_organ = pick("heart","lungs","liver","kidneys")
 		var/datum/internal_organ/I =  H.internal_organs_by_name[affected_organ]
 			I.damage += 2


### PR DESCRIPTION
Adjust damage verbs were used only by simple mobs and xenos, though they follow the logic of humans in where double max health damage kills someone. Xenos have a different condition to die: less than critical health, which is `-100`. This caused the edge case of the weaker of xenos, the Young Runner, having 100 life and being able to take at most 200 damage of each kind. In order to die it would require to be under -100, that is why no matter how many bullets it took, it would stay alive, unless if it took 1 damage of another kind as well, like fire.
Larvas had a snowflake critical health, bypassing this.

* Added procs to adjust and reset pain vars.
* Added resetting of halloss, pain, stagger and slowdown vars, plus maximum plasma, to rejuvenate()
* Xenos no longer share the healing procs with simple mobs, to adjust for their specificity.
* Xeno healing proc tweaked a bit. It's easier to die if in crit and off-weeds, but recovery while on crit in weeds is much improved.
* Larvas heal fast anywhere, as long as not in crit and out of weeds.
* Fixes xenos being unable to heal without a living queen.
* Shooting at xeno's head no longer does +14% extra damage. That was a bad idea we inherited.
* Clean a bit of code
* Action button icons get updated in the life proc regardless of plasma amount.
* Only the drone tree can, again, pick facehuggers.
* Xenos without a queen can heal again.
* Pain vars and procs are for carbon, not for all the living.
* update_action_button_icons() defined for those that have actions