### PR TITLE
Makes SMG AP ammo perform better

### DIFF
--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -409,8 +409,7 @@
 
 /datum/ammo/bullet/smg/ap/New()
 	..()
-	scatter = config.min_scatter_value
-	damage = config.llow_hit_damage
+	damage = config.mlow_hit_damage
 	penetration= config.med_armor_penetration
 
 /datum/ammo/bullet/smg/ppsh


### PR DESCRIPTION
-Damage changed from 20 - > 25 , for reference: regular smg ammo is 30 damage, regular M41 ammo is 40 damage and AP M41 ammo is 35 damage
-Scatter penalty on SMG AP ammo removed

Reasoning for change is based on local testing; SMG AP ammo was underperforming always compared to regular ammo, no matter if shooting low armor or high armored castes.