### PR TITLE
Defender: Fortify/Defensive Stance Improvements

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -646,10 +646,6 @@
 // Defender Crest Defense
 /mob/living/carbon/Xenomorph/proc/toggle_crest_defense()
 
-	if (fortify)
-		to_chat(src, "<span class='xenowarning'>You cannot use abilities while fortified.</span>")
-		return
-
 	if (!check_state())
 		return
 
@@ -660,8 +656,20 @@
 	used_crest_defense = TRUE
 
 	if (crest_defense)
+		if(fortify)
+			if(!used_fortify)
+				toggle_crest_defense()
+				to_chat(src, "<span class='xenowarning'>You carefully untuck, keeping your crest lowered.</span>")
+				fortify = FALSE
+				fortify_off()
+			else
+				to_chat(src, "<span class='xenowarning'>You cannot yet untuck yourself!</span>")
+				crest_defense = !crest_defense
+				used_crest_defense = FALSE
+				return
+		else
+			to_chat(src, "<span class='xenowarning'>You tuck yourself into a defensive stance.</span>")
 		round_statistics.defender_crest_lowerings++
-		to_chat(src, "<span class='xenowarning'>You lower your crest.</span>")
 		armor_bonus += DEFENDER_CRESTDEFENSE_ARMOR
 		speed_modifier += DEFENDER_CRESTDEFENSE_SLOWDOWN	// This is actually a slowdown but speed is dumb
 		update_icons()
@@ -686,10 +694,6 @@
 
 // Defender Fortify
 /mob/living/carbon/Xenomorph/proc/fortify()
-	if (crest_defense)
-		to_chat(src, "<span class='xenowarning'>You cannot use abilities with your crest lowered.</span>")
-		return
-
 	if (!check_state())
 		return
 
@@ -702,35 +706,34 @@
 	used_fortify = TRUE
 
 	if (fortify)
-		to_chat(src, "<span class='xenowarning'>You tuck yourself into a defensive stance.</span>")
+		if (crest_defense)
+			if(!used_crest_defense)
+				toggle_crest_defense()
+				to_chat(src, "<span class='xenowarning'>You tuck your lowered crest into yourself.</span>")
+			else
+				to_chat(src, "<span class='xenowarning'>You cannot yet transition to a defensive stance!</span>")
+				fortify = !fortify
+				used_fortify = FALSE
+				return
+		else
+			to_chat(src, "<span class='xenowarning'>You tuck yourself into a defensive stance.</span>")
 		armor_bonus += DEFENDER_FORTIFY_ARMOR
-		xeno_explosion_resistance++
+		xeno_explosion_resistance = 3
 		frozen = TRUE
 		anchored = TRUE
 		update_canmove()
 		update_icons()
 		do_fortify_cooldown()
-		fortify_timer = world.timeofday + 90		// How long we can be fortified
-		process_fortify()
 		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 30, 1)
 		return
 
 	fortify_off()
 	do_fortify_cooldown()
 
-/mob/living/carbon/Xenomorph/proc/process_fortify()
-	set background = 1
-
-	spawn while (fortify)
-		if (world.timeofday > fortify_timer)
-			fortify = FALSE
-			fortify_off()
-		sleep(10)	// Process every second.
-
 /mob/living/carbon/Xenomorph/proc/fortify_off()
 	to_chat(src, "<span class='xenowarning'>You resume your normal stance.</span>")
 	armor_bonus -= DEFENDER_FORTIFY_ARMOR
-	xeno_explosion_resistance--
+	xeno_explosion_resistance = 0
 	frozen = FALSE
 	anchored = FALSE
 	playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 30, 1)

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -139,9 +139,8 @@
 
 	var/headbutt_cooldown = 40
 	var/tail_sweep_cooldown = 120
-	var/crest_defense_cooldown = 150
-	var/fortify_cooldown = 200
-	var/fortify_timer = 60
+	var/crest_defense_cooldown = 20
+	var/fortify_cooldown = 20
 
 	//Praetorian vars
 	var/acid_spray_range = 3

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -110,12 +110,23 @@
 		if(!isliving(M))
 			return
 		var/impact_message = ""
+		if(isXeno(M))
+			var/mob/living/carbon/Xenomorph/D = M
+			if(D.fortify) //If we're fortified we don't give a shit about staggerstun.
+				impact_message += "<span class='xenodanger'>Your fortified stance braces you against the impact.</span>"
+				return
+			if(D.crest_defense) //Crest defense halves all effects, and protects us from the stun.
+				impact_message += "<span class='xenodanger'>Your crest protects you against some of the impact.</span>"
+				slowdown *= 0.5
+				stagger *= 0.5
+				stun = 0
 		if(shake)
 			shake_camera(M, shake+2, shake+3)
 			if(isXeno(M))
 				impact_message += "<span class='xenodanger'>You are shaken by the sudden impact!</span>"
 			else
 				impact_message += "<span class='warning'>You are shaken by the sudden impact!</span>"
+
 		//Check for and apply hard CC.
 		if(((isYautja(M) || M.mob_size == MOB_SIZE_BIG) && hard_size_threshold > 2) || (M.mob_size == MOB_SIZE_XENO && hard_size_threshold > 1) || (ishuman(M) && hard_size_threshold > 0))
 			var/mob/living/L = M


### PR DESCRIPTION
-Fortify and Defensive Stance are now more of a toggle, and can be used/transitioned between while the other is active; you still cannot use other Defender abilities while either is active. There is a short 2 second cooldown before you can toggle on/off either.

-You can now remain in Fortify stance indefinitely.

-Fortify grants Crusher level explosive resistance and grants immunity to staggerstun (such as from slugs) while it's active.

-Defensive stance halves the effect of staggerstun and negates its stun.
