### PR TITLE
Melee Tweak

### DIFF
--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -35,7 +35,8 @@
 	name = "\improper M2132 machete"
 	desc = "Latest issue of the USCM Machete. Great for clearing out jungle or brush on outlying colonies. Found commonly in the hands of scouts and trackers, but difficult to carry with the usual kit."
 	icon_state = "machete"
-	force = 35
+	force = 40
+	attack_speed = 9
 	w_class = 4.0
 
 /obj/item/weapon/claymore/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
@@ -83,6 +84,7 @@
 	throwforce = 20
 	throw_speed = 3
 	throw_range = 6
+	attack_speed = 8
 	hitsound = 'sound/weapons/slash.ogg'
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 

--- a/code/game/objects/items/weapons/blades.dm
+++ b/code/game/objects/items/weapons/blades.dm
@@ -84,7 +84,7 @@
 	throwforce = 20
 	throw_speed = 3
 	throw_range = 6
-	attack_speed = 8
+	attack_speed = 7
 	hitsound = 'sound/weapons/slash.ogg'
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 


### PR DESCRIPTION
-Machete attack damage increased by +5 to 40, and attack delay decreased to 9 down from 11 (about a 22% increase in attack speed). DPS increased from ~32 to ~49.

-Combat knife attack delay reduced from 11 to 7 (~57.14% increase in attack speed) . DPS increased from ~23 to 35.71

-Effect/impact of the changes is to make pure melee a little more competitive vs bayos, and to improve the knife and machete's niches as weed clearers.