### PR TITLE
Clean some errors in the code.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -5,27 +5,6 @@
 #define BORGTHERM 2
 #define BORGXRAY  4
 
-
-/*
-	reagents defines
-*/
-#define REAGENTS_OVERDOSE 30
-#define REAGENTS_OVERDOSE_CRITICAL 50
-
-// How many units of reagent are consumed per tick, by default.
-#define REAGENTS_METABOLISM 0.2
-// By defining the effect multiplier this way, it'll exactly adjust
-// all effects according to how they originally were with the 0.4 metabolism
-#define REAGENTS_EFFECT_MULTIPLIER REAGENTS_METABOLISM / 0.4
-
-#define REM REAGENTS_EFFECT_MULTIPLIER
-// Reagent metabolism defines.
-#define FOOD_METABOLISM 0.4
-#define ALCOHOL_METABOLISM 0.1
-
-// Factor of how fast mob nutrition decreases
-#define HUNGER_FACTOR 0.05
-
 //Pain or shock reduction for different reagents
 #define PAIN_REDUCTION_VERY_LIGHT	-10 //alkysine
 #define PAIN_REDUCTION_LIGHT		-25 //inaprovaline

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -36,6 +36,19 @@
 #define REAGENTS_OVERDOSE 30
 #define REAGENTS_OVERDOSE_CRITICAL 50
 
+// How many units of reagent are consumed per tick, by default.
+#define REAGENTS_METABOLISM 0.2
+// By defining the effect multiplier this way, it'll exactly adjust
+// all effects according to how they originally were with the 0.4 metabolism
+#define REAGENTS_EFFECT_MULTIPLIER REAGENTS_METABOLISM / 0.4
+
+// Reagent metabolism defines.
+#define FOOD_METABOLISM 0.4
+#define ALCOHOL_METABOLISM 0.1
+
+// Factor of how fast mob nutrition decreases
+#define HUNGER_FACTOR 0.05
+
 //Flags for reagents
 #define REAGENT_NOREACT (1<<0) //until we get to GLOB. lists and vars.
 

--- a/code/controllers/ProcessScheduler/stubs.dm
+++ b/code/controllers/ProcessScheduler/stubs.dm
@@ -35,7 +35,6 @@
 /datum/var/disposed
 
 #define DELTA_CALC max(max(world.tick_usage, world.cpu) / 100, 1)
-#define CEILING(x, y) ( -round(-(x) / (y)) * (y) )
 #define DS2TICKS(DS) ((DS)/world.tick_lag)
 //returns the number of ticks slept
 /proc/stoplag(initial_delay)

--- a/code/game/area/almayer.dm
+++ b/code/game/area/almayer.dm
@@ -27,26 +27,6 @@
 	icon_state = "shuttle"
 	fake_zlevel = 3
 
-/obj/machinery/computer/shuttle_control/almayer/hangar
-	name = "Elevator Console"
-	icon = 'icons/obj/machines/computer.dmi'
-	icon_state = "supply"
-	unacidable = 1
-	exproof = 1
-	density = 1
-	req_access = null
-	shuttle_tag = "Hangar"
-
-/obj/machinery/computer/shuttle_control/almayer/maintenance
-	name = "Elevator Console"
-	icon = 'icons/obj/machines/computer.dmi'
-	icon_state = "shuttle"
-	unacidable = 1
-	exproof = 1
-	density = 1
-	req_access = null
-	shuttle_tag = "Maintenance"
-
 /area/almayer/command/cic
 	name = "\improper Combat Information Center"
 	icon_state = "cic"

--- a/code/modules/reagents/chemistry_reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry_reagents/alcohol.dm
@@ -436,7 +436,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/bloody_mary/on_mob_life(mob/living/carbon/C)
 	if(C.blood_volume < BLOOD_VOLUME_NORMAL)
 		C.blood_volume += 0.3 //Bloody Mary slowly restores blood loss.
-..()
+	return ..()
 
 /datum/reagent/consumable/ethanol/brave_bull
 	name = "Brave Bull"

--- a/code/modules/reagents/chemistry_reagents/food.dm
+++ b/code/modules/reagents/chemistry_reagents/food.dm
@@ -429,4 +429,4 @@
 		M.adjustFireLoss(-1*REM, 0)
 		M.adjustOxyLoss(-1*REM, 0)
 		M.adjustToxLoss(-1*REM, 0)
-..()
+	return ..()

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -412,7 +412,27 @@
 	req_access = list(ACCESS_MARINE_DROPSHIP)
 
 
+//Hangar elevator console
 
+/obj/machinery/computer/shuttle_control/almayer/hangar
+	name = "Elevator Console"
+	icon = 'icons/obj/machines/computer.dmi'
+	icon_state = "supply"
+	unacidable = 1
+	exproof = 1
+	density = 1
+	req_access = null
+	shuttle_tag = "Hangar"
+
+/obj/machinery/computer/shuttle_control/almayer/maintenance
+	name = "Elevator Console"
+	icon = 'icons/obj/machines/computer.dmi'
+	icon_state = "shuttle"
+	unacidable = 1
+	exproof = 1
+	density = 1
+	req_access = null
+	shuttle_tag = "Maintenance"
 
 
 //Elevator control console


### PR DESCRIPTION
- Fixes #417  overwriting several defines in `mobs.dm` and using improper indentation on `..()` procs at the end.

- Fixes #339 redefining `CEILING(x, y)` which had been previously defined by #235 

- Fixes elevator consoles being redefined before actually being defined. Inherited issue.