### PR TITLE
Balance Patch

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/Powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/Powers.dm
@@ -434,14 +434,11 @@
 	var/mob/living/carbon/human/H = M
 	var/datum/limb/L = H.get_limb(check_zone(zone_selected))
 
-	if (!L || L.body_part == UPPER_TORSO || L.body_part == LOWER_TORSO || (L.status & LIMB_DESTROYED)) //Only limbs and head.
+	if (!L || L.body_part == UPPER_TORSO || L.body_part == LOWER_TORSO || (L.status & LIMB_DESTROYED) || L.body_part == HEAD) //Only limbs; no head
 		to_chat(src, "<span class='xenowarning'>You can't rip off that limb.</span>")
 		return FALSE
 	round_statistics.warrior_limb_rips++
 	var/limb_time = rand(40,60)
-
-	if (L.body_part == HEAD)
-		limb_time = rand(90,110)
 
 	visible_message("<span class='xenowarning'>\The [src] begins pulling on [M]'s [L.display_name] with incredible strength!</span>", \
 	"<span class='xenowarning'>You begin to pull on [M]'s [L.display_name] with incredible strength!</span>")

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -123,8 +123,8 @@
 	var/used_punch = 0
 	var/used_toggle_agility = 0
 
-	var/lunge_cooldown = 40
-	var/fling_cooldown = 40
+	var/lunge_cooldown = 120
+	var/fling_cooldown = 60
 	var/punch_cooldown = 40
 	var/toggle_agility_cooldown = 5
 

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -149,14 +149,19 @@
 			#endif
 		to_chat(M, "[impact_message]") //Summarize all the bad shit that happened
 
-	proc/burst(atom/target, obj/item/projectile/P, damage_type = BRUTE)
+	proc/burst(atom/target, obj/item/projectile/P, damage_type = BRUTE, radius = 1, modifier = 0.5, attack_type = "bullet", apply_armor = TRUE)
 		if(!target || !P)
 			return
-		for(var/mob/living/carbon/M in orange(1,target))
+		for(var/mob/living/carbon/M in orange(radius,target))
 			if(P.firer == M)
 				continue
 			M.visible_message("<span class='danger'>[M] is hit by backlash from \a [P.name]!</span>","[isXeno(M)?"<span class='xenodanger'>":"<span class='highdanger'>"]You are hit by backlash from \a </b>[P.name]</b>!</span>")
-			M.apply_damage(rand(5,P.damage/2),damage_type)
+			if(apply_armor)
+				var/armor_block = M.run_armor_check(M, attack_type)
+				M.apply_damage(rand(P.damage * modifier * 0.1,P.damage * modifier),damage_type, null, armor_block)
+			else
+				M.apply_damage(rand(P.damage * modifier * 0.1,P.damage * modifier),damage_type)
+
 
 	proc/fire_bonus_projectiles(obj/item/projectile/original_P)
 		set waitfor = 0
@@ -487,14 +492,14 @@
 
 /datum/ammo/bullet/rifle/m4ra/impact/New()
 	..()
-	damage = config.hmed_hit_damage
+	damage = config.med_hit_damage
 	accuracy = -config.low_hit_accuracy
 	scatter = -config.low_scatter_value
 	penetration= config.low_armor_penetration
 	shell_speed = config.fast_shell_speed
 
 /datum/ammo/bullet/rifle/m4ra/impact/on_hit_mob(mob/M, obj/item/projectile/P)
-	knockback(M, P, config.max_shell_range)
+	staggerstun(M, P, config.max_shell_range, 0, 1, 1)
 
 /datum/ammo/bullet/rifle/mar40
 	name = "heavy rifle bullet"
@@ -702,12 +707,9 @@
 
 /datum/ammo/bullet/sniper/flak/New()
 	..()
-	accuracy = -config.low_hit_accuracy
-	max_range = config.norm_shell_range
-	scatter = config.low_scatter_value
-	damage = config.hmed_hit_damage
+	damage = config.max_hit_damage
 	damage_var_high = config.low_proj_variance
-	penetration= -config.min_armor_penetration
+	penetration= -config.mlow_armor_penetration
 
 /datum/ammo/bullet/sniper/flak/on_hit_mob(mob/M,obj/item/projectile/P)
 	burst(get_turf(M),P,damage_type)


### PR DESCRIPTION
-Warriors can no longer tear off heads.

-Warrior Fling ability cooldown increased from 4 seconds to 6 seconds.

-Warrior Lunge ability cooldown increased from 4 seconds to 10 seconds.

-Flak rounds made much more powerful, along with the aoe damage, albeit at the cost of slightly less armour pen; they should no longer be useless.

-Impact rounds now deal slightly more damage, but apply a staggerstun instead of their old knockdown effect.