### PR TITLE
Ladder bug fix.

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -1,8 +1,3 @@
-
-
-/mob
-	var/list/fullscreens = list()
-
 /mob/proc/overlay_fullscreen(category, type, severity)
 	var/obj/screen/fullscreen/FS
 	if(fullscreens[category])

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -12,7 +12,6 @@
 	layer = LADDER_LAYER
 	var/is_watching = 0
 	var/obj/machinery/camera/cam
-	var/busy = 0 //Ladders are wonderful creatures, only one person can use it at a time
 
 /obj/structure/ladder/New()
 	..()
@@ -68,9 +67,6 @@
 /obj/structure/ladder/attack_hand(mob/user)
 	if(user.stat || get_dist(user, src) > 1 || is_blind(user) || user.lying || user.buckled || user.anchored)
 		return
-	if(busy)
-		to_chat(user, "<span class='warning'>Someone else is currently using [src].</span>")
-		return
 	var/ladder_dir_name
 	var/obj/structure/ladder/ladder_dest
 	if(up && down)
@@ -91,30 +87,15 @@
 	step(user, get_dir(user, src))
 	user.visible_message("<span class='notice'>[user] starts climbing [ladder_dir_name] [src].</span>",
 	"<span class='notice'>You start climbing [ladder_dir_name] [src].</span>")
-	busy = TRUE
-	if(do_after(user, 20, FALSE, 5, BUSY_ICON_GENERIC))
-		if(!user.is_mob_incapacitated() && get_dist(user, src) <= 1 && !is_blind(user) && !user.lying && !user.buckled && !user.anchored)
-			//TODO: Using forceMove is desirable here, but this breaks the pull. If you know how to preserve the pull, this would be nice!
-			user.loc = ladder_dest.loc //Cannot use forceMove method on pulls! Move manually //Make sure we move before we broadcast the message
-			var/mob/living/M = user
-			M.smokecloak_off()
-			visible_message("<span class='notice'>[user] climbs [ladder_dir_name] [src].</span>") //Hack to give a visible message to the people here without duplicating user message
-			user.visible_message("<span class='notice'>[user] climbs [ladder_dir_name] [src].</span>",
-			"<span class='notice'>You climb [ladder_dir_name] [src].</span>")
-			ladder_dest.add_fingerprint(user)
-			if(user.pulling && get_dist(src, user.pulling) <= 2)
-				user.pulling.loc = ladder_dest.loc //Cannot use forceMove method on pulls! Move manually
-				var/mob/living/P = user.pulling
-				P.smokecloak_off()
-				if(isobj(user.pulling))
-					var/obj/O = user.pulling
-					if(O.buckled_mob)
-						O.buckled_mob.loc = ladder_dest.loc //Cannot use forceMove method on pulls! Move manually
-						O.buckled_mob.smokecloak_off()
-		busy = FALSE
-	else 
-		busy = FALSE
 	add_fingerprint(user)
+	if(!do_after(user, 20, FALSE, 5, BUSY_ICON_GENERIC))
+		return
+	if(!user.is_mob_incapacitated() && get_dist(user, src) <= 1 && !is_blind(user) && !user.lying && !user.anchored)
+		user.trainteleport(ladder_dest.loc)
+		visible_message("<span class='notice'>[user] climbs [ladder_dir_name] [src].</span>") //Hack to give a visible message to the people here without duplicating user message
+		user.visible_message("<span class='notice'>[user] climbs [ladder_dir_name] [src].</span>",
+		"<span class='notice'>You climb [ladder_dir_name] [src].</span>")
+		ladder_dest.add_fingerprint(user)
 
 /obj/structure/ladder/attack_paw(mob/user as mob)
 	return attack_hand(user)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -91,7 +91,7 @@
 	step(user, get_dir(user, src))
 	user.visible_message("<span class='notice'>[user] starts climbing [ladder_dir_name] [src].</span>",
 	"<span class='notice'>You start climbing [ladder_dir_name] [src].</span>")
-	busy = 1
+	busy = TRUE
 	if(do_after(user, 20, FALSE, 5, BUSY_ICON_GENERIC))
 		if(!user.is_mob_incapacitated() && get_dist(user, src) <= 1 && !is_blind(user) && !user.lying && !user.buckled && !user.anchored)
 			//TODO: Using forceMove is desirable here, but this breaks the pull. If you know how to preserve the pull, this would be nice!
@@ -111,7 +111,9 @@
 					if(O.buckled_mob)
 						O.buckled_mob.loc = ladder_dest.loc //Cannot use forceMove method on pulls! Move manually
 						O.buckled_mob.smokecloak_off()
-	busy = 0
+		busy = FALSE
+	else 
+		busy = FALSE
 	add_fingerprint(user)
 
 /obj/structure/ladder/attack_paw(mob/user as mob)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -314,16 +314,6 @@
 /mob/living/carbon/human/ignore_pull_delay()
 	return has_species(src,"Yautja") //Predators aren't slowed when pulling their prey.
 
-/mob/living/forceMove(atom/destination)
-	stop_pulling()
-	if(pulledby)
-		pulledby.stop_pulling()
-	if(buckled)
-		buckled.unbuckle()
-	. = ..()
-	if(.)
-		reset_view(destination)
-
 /mob/living/proc/can_inject()
 	return TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -647,4 +647,82 @@ mob/proc/yank_out_object()
 	if(istype(AM, /obj/item))
 		temp_drop_inv_item(AM, TRUE) //unequip before deletion to clear possible item references on the mob.
 
+/mob/forceMove(atom/destination)
+	stop_pulling()
+	if(pulledby)
+		pulledby.stop_pulling()
+	if(buckled)
+		buckled.unbuckle()
+	. = ..()
+	if(.)
+		reset_view(destination)
 
+/mob/proc/trainteleport(atom/destination)
+	if(!destination || anchored)
+		return FALSE //Gotta go somewhere and be able to move
+	if(!pulling)
+		return forceMove(destination) //No need for a special proc if there's nothing being pulled.
+	pulledby?.stop_pulling() //The leader of the choo-choo train breaks the pull
+	var/atom/movable/list/conga_line[0]
+	var/end_of_conga = FALSE
+	var/mob/S = src
+	conga_line += S
+	if(S.buckled)
+		if(S.buckled.anchored)
+			S.buckled.unbuckle() //Unbuckle the first of the line if anchored.
+		else
+			conga_line += S.buckled
+	while(!end_of_conga)
+		var/atom/movable/A = S.pulling
+		if(A in conga_line || A.anchored) //No loops, nor moving anchored things.
+			end_of_conga = TRUE
+			break
+		conga_line += A
+		var/mob/M = A
+		if(istype(M)) //Is a mob
+			var/mob/living/L = M
+			if(istype(L))
+				L.smokecloak_off()
+			if(M.buckled && !(M.buckled in conga_line))
+				if(M.buckled.anchored)
+					M.buckled.unbuckle() //Force the dragged people out of anchored buckles.
+				else
+					conga_line += M.buckled //Or bring the buckles along.
+			if(M.pulling)
+				S = M
+			else
+				end_of_conga = TRUE
+		else //Not a mob.
+			var/obj/O = A
+			if(istype(O) && O.buckled_mob) //But can have a mob associated.
+				conga_line += O.buckled_mob
+				if(O.buckled_mob.pulling) //Unlikely, but who knows? A train of wheelchairs?
+					S = O.buckled_mob
+					continue
+			var/obj/structure/bed/B = O
+			if(istype(B) && B.buckled_bodybag)
+				conga_line += B.buckled_bodybag
+			end_of_conga = TRUE //Only mobs can continue the cycle.
+	var/area/new_area = get_area(destination)
+	for(var/atom/movable/AM in conga_line)
+		var/oldLoc
+		if(AM.loc)
+			oldLoc = AM.loc
+			AM.loc.Exited(AM,destination)
+		AM.loc = destination
+		AM.loc.Entered(AM,oldLoc)
+		var/area/old_area
+		if(oldLoc)
+			old_area = get_area(oldLoc)
+		if(new_area && old_area != new_area)
+			new_area.Entered(AM,oldLoc)
+		for(var/atom/movable/CR in destination)
+			if(CR in conga_line)
+				continue
+			CR.Crossed(AM)
+		if(oldLoc)
+			AM.Moved(oldLoc)
+		var/mob/M = AM
+		if(istype(M))
+			M.reset_view(destination)
+	return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -680,14 +680,16 @@ mob/proc/yank_out_object()
 		conga_line += A
 		var/mob/M = A
 		if(istype(M)) //Is a mob
+			if(M.buckled && !(M.buckled in conga_line))
+				if(M.buckled.anchored)
+					conga_line -= A //Remove from the conga line if on anchored buckles.
+					end_of_conga = TRUE //Party is over, they won't be dragging anyone themselves.
+					break
+				else
+					conga_line += M.buckled //Or bring the buckles along.
 			var/mob/living/L = M
 			if(istype(L))
 				L.smokecloak_off()
-			if(M.buckled && !(M.buckled in conga_line))
-				if(M.buckled.anchored)
-					M.buckled.unbuckle() //Force the dragged people out of anchored buckles.
-				else
-					conga_line += M.buckled //Or bring the buckles along.
 			if(M.pulling)
 				S = M
 			else

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -165,3 +165,5 @@
 	var/list/hud_possible //HUD images that this mob can provide.
 
 	var/action_busy //whether the mob is currently doing an action that takes time (do_after or do_mob procs)
+
+	var/list/fullscreens = list()


### PR DESCRIPTION
- Removed the limitation of one user per ladder. Supposed realism (questionable) here detracts from balance (worsening ladder camping/cheesing) and, more importantly, from fun (having to wait until someone else finishes using a ladder).
- Made a proc to handle teleporting mobs while preserving grabs, teleporting all the unanchored objects and mobs associated, unbuckling them if necessary.