### PR TITLE
Gives admins their newscaster back

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -89,6 +89,7 @@ var/list/admin_verbs_sounds = list(
 	)
 var/list/admin_verbs_fun = list(
 	// /client/proc/object_talk,
+	/datum/admins/proc/access_news_network,
 	/client/proc/cmd_admin_dress,
 	/client/proc/cmd_admin_select_mob_rank,
 	/client/proc/cmd_admin_gib_self,


### PR DESCRIPTION
`/datum/admins/proc/access_news_network()` is now a +FUN verb.