### PR TITLE
Fixes empty antitox pills

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -236,7 +236,7 @@
 /obj/item/storage/pill_bottle/antitox
 	name = "dylovene pill bottle"
 	icon_state = "pill_canister6"
-	pill_type_to_fill = /obj/item/reagent_container/pill/antitox
+	pill_type_to_fill = /obj/item/reagent_container/pill/dylovene
 
 /obj/item/storage/pill_bottle/inaprovaline
 	name = "inaprovaline pill bottle"


### PR DESCRIPTION
For some reason these were spawning with default style pills, and I can't really find where the hell the old type was defined.