### PR TITLE
Fixes anti-tox change in #566

### DIFF
--- a/code/game/objects/items/reagent_containers/pill.dm
+++ b/code/game/objects/items/reagent_containers/pill.dm
@@ -120,6 +120,11 @@ var/global/list/randomized_pill_icons
 /obj/item/reagent_container/pill/dylovene
 	pill_desc = "A dylovene pill. It neutralizes many common toxins."
 	list_reagents = list("dylovene" = 25)
+
+/obj/item/reagent_container/pill/antitox
+	pill_desc = "An anti-toxins pill. It neutralizes many common toxins."
+	list_reagents = list("anti_toxin" = 25)
+
 /obj/item/reagent_container/pill/antitox/New()
 	. = ..()
 	icon_state = randomized_pill_icons[1]


### PR DESCRIPTION
#566 removed the declaration/definition of antitox:
https://github.com/ColonialMarines-Mirror/ColonialMarines-2018/pull/566/files#diff-ebcea53e6caa93556d0057343cb88e24L120

This resulted in an empty pill.