### PR TITLE
M41A MK2: Burst Fire Delay Reduced By 0.05 Seconds

### DIFF
--- a/code/controllers/settings/combat_defines.dm
+++ b/code/controllers/settings/combat_defines.dm
@@ -76,6 +76,7 @@
 	var/max_burst_value = 6
 
 	var/min_fire_delay = 1
+	var/vlow_fire_delay = 1.5
 	var/mlow_fire_delay = 2
 	var/low_fire_delay = 3
 	var/med_fire_delay = 4
@@ -304,6 +305,8 @@
 
 		if("min_fire_delay")
 			min_fire_delay = value
+		if("vlow_fire_delay")
+			vlow_fire_delay = value
 		if("mlow_fire_delay")
 			mlow_fire_delay = value
 		if("low_fire_delay")

--- a/code/modules/projectiles/updated_projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/rifles.dm
@@ -75,7 +75,7 @@
 /obj/item/weapon/gun/rifle/m41a/set_gun_config_values()
 	fire_delay = config.med_fire_delay
 	burst_amount = config.med_burst_value
-	burst_delay = config.mlow_fire_delay
+	burst_delay = config.vlow_fire_delay
 	accuracy_mult = config.base_hit_accuracy_mult
 	accuracy_mult_unwielded = config.base_hit_accuracy_mult - config.high_hit_accuracy_mult
 	scatter = config.med_scatter_value

--- a/config/example/combat_defines.txt
+++ b/config/example/combat_defines.txt
@@ -85,6 +85,7 @@ MAX_BURST_VALUE 6
 ##FIRE DELAY
 ##Ticks before the weapon can be fired again. Should be 6 for regular delay and 2 for burst delay.
 MIN_FIRE_DELAY 1
+VLOW_FIRE_DELAY 1.5
 MLOW_FIRE_DELAY 2
 LOW_FIRE_DELAY 3
 MED_FIRE_DELAY 4


### PR DESCRIPTION
Hopefully this will make builds other than EB + QFA + Angled Grip  (which penalizes bursting) more viable.