### PR TITLE
Xeno Queen rolling rework + monkey rebalance.

### DIFF
--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -90,7 +90,8 @@ Additional game mode variables.
 
 datum/game_mode/proc/initialize_special_clamps()
 	var/ready_players = num_players() // Get all players that have "Ready" selected
-	xeno_starting_num = max((ready_players/7), xeno_required_num) //(n, minimum, maximum)
+	//xeno_starting_num = max((ready_players/7), xeno_required_num) //(n, minimum, maximum)
+	xeno_starting_num = 1
 	surv_starting_num = CLAMP((ready_players/25), 0, 8)
 	merc_starting_num = max((ready_players/3), 1)
 	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num
@@ -280,22 +281,28 @@ datum/game_mode/proc/initialize_special_clamps()
 	message_admins("DEBUG: Initializing starting xenomorph list.")
 	var/list/datum/mind/possible_xenomorphs = get_players_for_role(BE_ALIEN)
 	if(possible_xenomorphs.len < xeno_required_num) //We don't have enough aliens.
-		to_chat(world, "<h2 style=\"color:red\">Not enough players have chosen to be a xenomorph in their character setup. <b>Aborting</b>.</h2>")
+		message_admins("DEBUG: Noone had xeno preference on apparently, aborting filling the list.")
+		//to_chat(world, "<h2 style=\"color:red\">Not enough players have chosen to be a xenomorph in their character setup. <b>Aborting</b>.</h2>")
 		return
 
 	//Minds are not transferred at this point, so we have to clean out those who may be already picked to play.
 	for(var/datum/mind/A in possible_xenomorphs)
 		if(A.assigned_role == "MODE")
+			message_admins("DEBUG: Assigned role mode?")
 			possible_xenomorphs -= A
+
+	for(var/datum/mind/A in possible_xenomorphs)
+		message_admins("Xenomorph possible candidate: [A]")
 
 	var/i = xeno_starting_num
 	var/datum/mind/new_xeno
 	var/turf/larvae_spawn
 	while(i > 0) //While we can still pick someone for the role.
 		if(possible_xenomorphs.len) //We still have candidates
+			message_admins("We still have candidates, yay.")
 			new_xeno = pick(possible_xenomorphs)
 			if(!new_xeno) 
-				message_admins("DEBUG: No possible xeno candidates?")
+				message_admins("DEBUG: Last candidate gone, aborting.")
 				break  //Looks like we didn't get anyone. Back out.
 			new_xeno.assigned_role = "MODE"
 			new_xeno.special_role = "Xenomorph"
@@ -312,8 +319,11 @@ datum/game_mode/proc/initialize_special_clamps()
 	Our list is empty. This can happen if we had someone ready as alien and predator, and predators are picked first.
 	So they may have been removed from the list, oh well.
 	*/
+	for(var/datum/mind/A in xenomorphs)
+		message_admins("Xenomorph picked candidate: [A]")
 	if(xenomorphs.len < xeno_required_num)
-		to_chat(world, "<h2 style=\"color:red\">Could not find any candidates after initial alien list pass. <b>Aborting</b>.</h2>")
+		//to_chat(world, "<h2 style=\"color:red\">Could not find any candidates after initial alien list pass. <b>Aborting</b>.</h2>")
+		message_admins("Xenomorph list didn't get properly filled.")
 		return
 
 	return TRUE
@@ -342,6 +352,7 @@ datum/game_mode/proc/initialize_special_clamps()
 	return TRUE
 
 /datum/game_mode/proc/initialize_post_xenomorph_list()
+	message_admins("Initializing post xenomorph list.")
 	for(var/datum/mind/new_xeno in xenomorphs) //Build and move the xenos.
 		if(new_xeno == queen)
 			message_admins("DEBUG:Queen also had xeno on, not picking them as xeno.")

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -91,7 +91,7 @@ Additional game mode variables.
 datum/game_mode/proc/initialize_special_clamps()
 	var/ready_players = num_players() // Get all players that have "Ready" selected
 	//xeno_starting_num = max((ready_players/7), xeno_required_num) //(n, minimum, maximum)
-	xeno_starting_num = 1
+	xeno_starting_num = ready_players
 	surv_starting_num = CLAMP((ready_players/25), 0, 8)
 	merc_starting_num = max((ready_players/3), 1)
 	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num
@@ -297,6 +297,7 @@ datum/game_mode/proc/initialize_special_clamps()
 	var/i = xeno_starting_num
 	var/datum/mind/new_xeno
 	var/turf/larvae_spawn
+	message_admin("DEBUG: [i] this is i.")
 	while(i > 0) //While we can still pick someone for the role.
 		if(possible_xenomorphs.len) //We still have candidates
 			message_admins("We still have candidates, yay.")
@@ -306,14 +307,15 @@ datum/game_mode/proc/initialize_special_clamps()
 				break  //Looks like we didn't get anyone. Back out.
 			new_xeno.assigned_role = "MODE"
 			new_xeno.special_role = "Xenomorph"
-			possible_xenomorphs -= new_xeno
 			xenomorphs += new_xeno
+			possible_xenomorphs -= new_xeno
 			message_admins("DEBUG: Adding [new_xeno] to Xenomorphs list")
 		else //Out of candidates, spawn in empty larvas directly
 			message_admins("DEBUG: Out of candidates, spawning larvas directly")
 			larvae_spawn = pick(xeno_spawn)
 			new /mob/living/carbon/Xenomorph/Larva(larvae_spawn)
 		i--
+	message_admin("DEBUG: Loop done?")
 
 	/*
 	Our list is empty. This can happen if we had someone ready as alien and predator, and predators are picked first.

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -322,6 +322,7 @@ datum/game_mode/proc/initialize_special_clamps()
 			possible_queens -= A
 
 	if(!possible_queens.len) //We still have candidates
+		message_admins("DEBUG: Noone had queen preference on.")
 		return FALSE
 
 	for(var/datum/mind/new_queen in possible_queens)
@@ -330,6 +331,7 @@ datum/game_mode/proc/initialize_special_clamps()
 			new_queen.special_role = "Xenomorph"
 			if(new_queen in xenomorphs)
 				xenomorphs -= new_queen
+				message_admins("DEBUG: Player also has xeno preference on, removing from xeno list.")
 			queen = new_queen
 			break
 
@@ -339,9 +341,12 @@ datum/game_mode/proc/initialize_special_clamps()
 	for(var/datum/mind/new_xeno in xenomorphs) //Build and move the xenos.
 		if(new_xeno != queen)
 			transform_xeno(new_xeno)
+		else
+			message_admins("Queen wasn't removed from xeno list properly.")
 
 datum/game_mode/proc/initialize_post_queen_list()
 	if(!queen)
+		message_admins("No queen candidate picked, returning.")
 		return
 	transform_queen(queen)
 
@@ -491,7 +496,9 @@ datum/game_mode/proc/initialize_post_queen_list()
 	var/datum/hive_status/hive = hive_datum[XENO_HIVE_NORMAL]
 	if(!hive.living_xeno_queen && original?.client?.prefs && (original.client.prefs.be_special & BE_QUEEN) && !jobban_isbanned(original, "Queen"))
 		new_queen = new /mob/living/carbon/Xenomorph/Queen (pick(xeno_spawn))
+		message_admins("DEBUG:Queen created.")
 	else
+		message_admins("DEBUG:Could not create Queen.")
 		return
 	ghost_mind.transfer_to(new_queen)
 	ghost_mind.name = ghost_mind.current.name
@@ -501,9 +508,10 @@ datum/game_mode/proc/initialize_post_queen_list()
 	to_chat(new_queen, "Talk in Hivemind using <strong>;</strong> (e.g. ';My life for the hive!')")
 
 	new_queen.update_icons()
+
 	if(original) 
 		cdel(original) //Just to be sure.
-
+	message_admins("DEBUG:Queen mind transfered properly, all good.")
 
 //===================================================\\
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -277,6 +277,7 @@ datum/game_mode/proc/initialize_special_clamps()
 //If we are selecting xenomorphs, we NEED them to play the round. This is the expected behavior.
 //If this is an optional behavior, just override this proc or make an override here.
 /datum/game_mode/proc/initialize_starting_xenomorph_list()
+	message_admins("DEBUG: Initializing starting xeno list.")
 	var/list/datum/mind/possible_xenomorphs = get_players_for_role(BE_ALIEN)
 	if(possible_xenomorphs.len < xeno_required_num) //We don't have enough aliens.
 		to_chat(world, "<h2 style=\"color:red\">Not enough players have chosen to be a xenomorph in their character setup. <b>Aborting</b>.</h2>")
@@ -318,6 +319,7 @@ datum/game_mode/proc/initialize_special_clamps()
 	return TRUE
 
 /datum/game_mode/proc/initialize_starting_queen_list()
+	message_admins("DEBUG: Initializing starting queen list.")
 	var/list/datum/mind/possible_queens = get_players_for_role(BE_QUEEN)
 
 	//Minds are not transferred at this point, so we have to clean out those who may be already picked to play.

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -322,7 +322,7 @@ datum/game_mode/proc/initialize_special_clamps()
 			possible_queens -= A
 
 	if(!possible_queens.len) //We still have candidates
-		return
+		return FALSE
 
 	for(var/datum/mind/new_queen in possible_queens)
 		if(!jobban_isbanned(new_queen.current))

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -321,20 +321,17 @@ datum/game_mode/proc/initialize_special_clamps()
 		if(A.assigned_role == "MODE")
 			possible_queens -= A
 
-	if(possible_queens.len) //We still have candidates
-		for(var/datum/mind/new_queen in possible_queens)
-			if(!jobban_isbanned(new_queen.current))
-				new_queen.assigned_role = "MODE"
-				new_queen.special_role = "Xenomorph"
-				if(new_queen in xenomorphs)
-					message_admins("DEBUG: Queen also had xeno pref on, removing them from xeno list")
-					xenomorphs -= new_queen
-				queen = new_queen
-				message_admins("DEBUG: Queen candidate picked properly")
-				break
-	else
-		message_admins("DEBUG: No possible queen candidates found")
+	if(!possible_queens.len) //We still have candidates
 		return
+
+	for(var/datum/mind/new_queen in possible_queens)
+		if(!jobban_isbanned(new_queen.current))
+			new_queen.assigned_role = "MODE"
+			new_queen.special_role = "Xenomorph"
+			if(new_queen in xenomorphs)
+				xenomorphs -= new_queen
+			queen = new_queen
+			break
 
 	return TRUE
 
@@ -342,12 +339,9 @@ datum/game_mode/proc/initialize_special_clamps()
 	for(var/datum/mind/new_xeno in xenomorphs) //Build and move the xenos.
 		if(new_xeno != queen)
 			transform_xeno(new_xeno)
-		else
-			message_admins("DEBUG: Player had both xeno and queen on and got rolled for queen, ignoring xeno roll.")
 
 datum/game_mode/proc/initialize_post_queen_list()
 	if(!queen)
-		message_admins("DEBUG: No possible queen to transform detected")
 		return
 	transform_queen(queen)
 
@@ -497,9 +491,7 @@ datum/game_mode/proc/initialize_post_queen_list()
 	var/datum/hive_status/hive = hive_datum[XENO_HIVE_NORMAL]
 	if(!hive.living_xeno_queen && original?.client?.prefs && (original.client.prefs.be_special & BE_QUEEN) && !jobban_isbanned(original, "Queen"))
 		new_queen = new /mob/living/carbon/Xenomorph/Queen (pick(xeno_spawn))
-		message_admins("DEBUG:Queen rolled correctly and mob created")
 	else
-		message_admins("DEBUG:Queen rolled correctly but failed conditions")
 		return
 	ghost_mind.transfer_to(new_queen)
 	ghost_mind.name = ghost_mind.current.name
@@ -509,7 +501,6 @@ datum/game_mode/proc/initialize_post_queen_list()
 	to_chat(new_queen, "Talk in Hivemind using <strong>;</strong> (e.g. ';My life for the hive!')")
 
 	new_queen.update_icons()
-	message_admins("DEBUG:Queen mind transfered, messages shown, basically all good.")
 	if(original) 
 		cdel(original) //Just to be sure.
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -495,7 +495,7 @@ datum/game_mode/proc/initialize_post_queen_list()
 	var/mob/original = ghost_mind.current
 	var/mob/living/carbon/Xenomorph/new_queen
 	var/datum/hive_status/hive = hive_datum[XENO_HIVE_NORMAL]
-	if(!hive.living_xeno_queen && original && original.client && original.client.prefs && (original.client.prefs.be_special & BE_QUEEN) && !jobban_isbanned(original, "Queen"))
+	if(!hive.living_xeno_queen && original?.client?.prefs && (original.client.prefs.be_special & BE_QUEEN) && !jobban_isbanned(original, "Queen"))
 		new_queen = new /mob/living/carbon/Xenomorph/Queen (pick(xeno_spawn))
 		message_admins("DEBUG:Queen rolled correctly and mob created")
 	else

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -297,7 +297,7 @@ datum/game_mode/proc/initialize_special_clamps()
 	var/i = xeno_starting_num
 	var/datum/mind/new_xeno
 	var/turf/larvae_spawn
-	message_admin("DEBUG: [i] this is i.")
+	message_admins("DEBUG: [i] this is i.")
 	while(i > 0) //While we can still pick someone for the role.
 		if(possible_xenomorphs.len) //We still have candidates
 			message_admins("We still have candidates, yay.")
@@ -315,7 +315,7 @@ datum/game_mode/proc/initialize_special_clamps()
 			larvae_spawn = pick(xeno_spawn)
 			new /mob/living/carbon/Xenomorph/Larva(larvae_spawn)
 		i--
-	message_admin("DEBUG: Loop done?")
+	message_admins("DEBUG: Loop done?")
 
 	/*
 	Our list is empty. This can happen if we had someone ready as alien and predator, and predators are picked first.

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -346,6 +346,7 @@ datum/game_mode/proc/initialize_special_clamps()
 		if(new_xeno == queen)
 			message_admins("DEBUG:Queen also had xeno on, not picking them as xeno.")
 		else
+			message_admins("DEBUG:Trying to transform xeno?")
 			transform_xeno(new_xeno)
 
 datum/game_mode/proc/initialize_post_queen_list()

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -290,7 +290,7 @@ datum/game_mode/proc/initialize_special_clamps()
 	var/datum/mind/new_xeno
 	var/turf/larvae_spawn
 	while(i > 0) //While we can still pick someone for the role.
-		if(possible_xenomorphs.len) //We still have candidates
+		if(length(possible_xenomorphs)) //We still have candidates
 			new_xeno = pick(possible_xenomorphs)
 			if(!new_xeno) 
 				break  //Looks like we didn't get anyone. Back out.
@@ -321,7 +321,7 @@ datum/game_mode/proc/initialize_special_clamps()
 		if(A.assigned_role == "MODE")
 			possible_queens -= A
 
-	if(!possible_queens.len)
+	if(!length(possible_queens))
 		return FALSE
 
 	for(var/datum/mind/new_queen in possible_queens)
@@ -527,7 +527,7 @@ datum/game_mode/proc/initialize_post_queen_list()
 			var/i = surv_starting_num
 			var/datum/mind/new_survivor
 			while(i > 0)
-				if(!possible_survivors.len) 
+				if(!length(possible_survivors)) 
 					break  //Ran out of candidates! Can't have a null pick(), so just stick with what we have.
 				new_survivor = pick(possible_survivors)
 				if(!new_survivor) 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -294,6 +294,7 @@ datum/game_mode/proc/initialize_special_clamps()
 		if(possible_xenomorphs.len) //We still have candidates
 			new_xeno = pick(possible_xenomorphs)
 			if(!new_xeno) 
+				message_admins("DEBUG: No possible candidates?")
 				break  //Looks like we didn't get anyone. Back out.
 			new_xeno.assigned_role = "MODE"
 			new_xeno.special_role = "Xenomorph"
@@ -533,9 +534,11 @@ datum/game_mode/proc/initialize_post_queen_list()
 			var/i = surv_starting_num
 			var/datum/mind/new_survivor
 			while(i > 0)
-				if(!possible_survivors.len) break  //Ran out of candidates! Can't have a null pick(), so just stick with what we have.
+				if(!possible_survivors.len) 
+					break  //Ran out of candidates! Can't have a null pick(), so just stick with what we have.
 				new_survivor = pick(possible_survivors)
-				if(!new_survivor) break  //We ran out of survivors!
+				if(!new_survivor) 
+					break  //We ran out of survivors!
 				new_survivor.assigned_role = "MODE"
 				new_survivor.special_role = "Survivor"
 				possible_survivors -= new_survivor

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -93,7 +93,7 @@ datum/game_mode/proc/initialize_special_clamps()
 	xeno_starting_num = max((ready_players/7), xeno_required_num) //(n, minimum, maximum)
 	surv_starting_num = CLAMP((ready_players/25), 0, 8)
 	merc_starting_num = max((ready_players/3), 1)
-	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num
+	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num - 1
 	for(var/datum/squad/sq in RoleAuthority.squads)
 		if(sq)
 			sq.max_engineers = engi_slot_formula(marine_starting_num)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -340,10 +340,13 @@ datum/game_mode/proc/initialize_special_clamps()
 
 /datum/game_mode/proc/initialize_post_xenomorph_list()
 	for(var/datum/mind/new_xeno in xenomorphs) //Build and move the xenos.
-		transform_xeno(new_xeno)
-	
+		if(new_xeno != queen)
+			transform_xeno(new_xeno)
+		else
+			message_admins("DEBUG: Player had both xeno and queen on and got rolled for queen, ignoring xeno roll.")
+
 datum/game_mode/proc/initialize_post_queen_list()
-	if (!queen)
+	if(!queen)
 		message_admins("DEBUG: No possible queen to transform detected")
 		return
 	transform_queen(queen)

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -325,13 +325,17 @@ datum/game_mode/proc/initialize_special_clamps()
 		return FALSE
 
 	for(var/datum/mind/new_queen in possible_queens)
-		if(!jobban_isbanned(new_queen.current))
-			new_queen.assigned_role = "MODE"
-			new_queen.special_role = "Xenomorph"
-			queen = new_queen
-			break
+		if(jobban_isbanned(new_queen.current))
+			continue
+		new_queen.assigned_role = "MODE"
+		new_queen.special_role = "Xenomorph"
+		queen = new_queen
+		break
 
-	return TRUE
+	if(!queen)
+		return FALSE
+	else
+		return TRUE
 
 /datum/game_mode/proc/initialize_post_xenomorph_list()
 	for(var/datum/mind/new_xeno in xenomorphs) //Build and move the xenos.

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -90,10 +90,10 @@ Additional game mode variables.
 
 datum/game_mode/proc/initialize_special_clamps()
 	var/ready_players = num_players() // Get all players that have "Ready" selected
-	xeno_starting_num = max((ready_players/7), xeno_required_num) //(n, minimum, maximum)
+	xeno_starting_num = max((ready_players/7), xeno_required_num)
 	surv_starting_num = CLAMP((ready_players/25), 0, 8)
 	merc_starting_num = max((ready_players/3), 1)
-	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num - 1
+	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num
 	for(var/datum/squad/sq in RoleAuthority.squads)
 		if(sq)
 			sq.max_engineers = engi_slot_formula(marine_starting_num)
@@ -102,7 +102,12 @@ datum/game_mode/proc/initialize_special_clamps()
 	for(var/datum/job/J in RoleAuthority.roles_by_name)
 		if(J.scaled)
 			J.set_spawn_positions(marine_starting_num)
-
+	message_admins("DEBUG: ready players [ready_players]")
+	message_admins("DEBUG: xeno_required_num [xeno_required_num]")
+	message_admins("DEBUG: xeno_starting_num [xeno_starting_num]")
+	message_admins("DEBUG: surv_starting_num [surv_starting_num]")
+	message_admins("DEBUG: merc_starting_num [merc_starting_num]")
+	message_admins("DEBUG: marine_starting_num [marine_starting_num]")
 
 //===================================================\\
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -293,12 +293,15 @@ datum/game_mode/proc/initialize_special_clamps()
 	while(i > 0) //While we can still pick someone for the role.
 		if(possible_xenomorphs.len) //We still have candidates
 			new_xeno = pick(possible_xenomorphs)
-			if(!new_xeno) break  //Looks like we didn't get anyone. Back out.
+			if(!new_xeno) 
+				break  //Looks like we didn't get anyone. Back out.
 			new_xeno.assigned_role = "MODE"
 			new_xeno.special_role = "Xenomorph"
 			possible_xenomorphs -= new_xeno
 			xenomorphs += new_xeno
+			message_admins("DEBUG: Adding [new_xeno] to Xenomorphs list")
 		else //Out of candidates, spawn in empty larvas directly
+			message_admins("DEBUG: Out of candidates, spawning larvas directly")
 			larvae_spawn = pick(xeno_spawn)
 			new /mob/living/carbon/Xenomorph/Larva(larvae_spawn)
 		i--
@@ -472,6 +475,7 @@ datum/game_mode/proc/initialize_post_queen_list()
 	if(xeno_candidate) xeno_candidate.loc = null
 
 /datum/game_mode/proc/transform_xeno(datum/mind/ghost_mind)
+	message_admins("DEBUG:Transforming Xeno")
 	var/mob/original = ghost_mind.current
 	var/mob/living/carbon/Xenomorph/new_xeno
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -91,7 +91,7 @@ Additional game mode variables.
 datum/game_mode/proc/initialize_special_clamps()
 	var/ready_players = num_players() // Get all players that have "Ready" selected
 	//xeno_starting_num = max((ready_players/7), xeno_required_num) //(n, minimum, maximum)
-	xeno_starting_num = ready_players
+	xeno_starting_num = 10
 	surv_starting_num = CLAMP((ready_players/25), 0, 8)
 	merc_starting_num = max((ready_players/3), 1)
 	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num
@@ -294,7 +294,7 @@ datum/game_mode/proc/initialize_special_clamps()
 	for(var/datum/mind/A in possible_xenomorphs)
 		message_admins("Xenomorph possible candidate: [A]")
 
-	var/i = xeno_starting_num
+	var/i = 10
 	var/datum/mind/new_xeno
 	var/turf/larvae_spawn
 	message_admins("DEBUG: [i] this is i.")

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -277,7 +277,7 @@ datum/game_mode/proc/initialize_special_clamps()
 //If we are selecting xenomorphs, we NEED them to play the round. This is the expected behavior.
 //If this is an optional behavior, just override this proc or make an override here.
 /datum/game_mode/proc/initialize_starting_xenomorph_list()
-	message_admins("DEBUG: Initializing starting xeno list.")
+	message_admins("DEBUG: Initializing starting xenomorph list.")
 	var/list/datum/mind/possible_xenomorphs = get_players_for_role(BE_ALIEN)
 	if(possible_xenomorphs.len < xeno_required_num) //We don't have enough aliens.
 		to_chat(world, "<h2 style=\"color:red\">Not enough players have chosen to be a xenomorph in their character setup. <b>Aborting</b>.</h2>")
@@ -295,7 +295,7 @@ datum/game_mode/proc/initialize_special_clamps()
 		if(possible_xenomorphs.len) //We still have candidates
 			new_xeno = pick(possible_xenomorphs)
 			if(!new_xeno) 
-				message_admins("DEBUG: No possible candidates?")
+				message_admins("DEBUG: No possible xeno candidates?")
 				break  //Looks like we didn't get anyone. Back out.
 			new_xeno.assigned_role = "MODE"
 			new_xeno.special_role = "Xenomorph"
@@ -343,10 +343,10 @@ datum/game_mode/proc/initialize_special_clamps()
 
 /datum/game_mode/proc/initialize_post_xenomorph_list()
 	for(var/datum/mind/new_xeno in xenomorphs) //Build and move the xenos.
-		if(new_xeno != queen)
-			transform_xeno(new_xeno)
-		else
+		if(new_xeno == queen)
 			message_admins("DEBUG:Queen also had xeno on, not picking them as xeno.")
+		else
+			transform_xeno(new_xeno)
 
 datum/game_mode/proc/initialize_post_queen_list()
 	if(!queen)
@@ -494,6 +494,7 @@ datum/game_mode/proc/initialize_post_queen_list()
 
 	if(original) 
 		cdel(original) //Just to be sure.
+	message_admins("DEBUG:Xeno transformed properly")
 
 /datum/game_mode/proc/transform_queen(datum/mind/ghost_mind)
 	var/mob/original = ghost_mind.current

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -315,6 +315,17 @@ datum/game_mode/proc/initialize_special_clamps()
 /datum/game_mode/proc/initialize_post_xenomorph_list()
 	for(var/datum/mind/new_xeno in xenomorphs) //Build and move the xenos.
 		transform_xeno(new_xeno)
+	for(var/mob/new_player/player in player_list)
+		if(player.client && player.ready && player.client.prefs && (player.client.prefs.be_special & BE_QUEEN) && !jobban_isbanned(player, "Queen"))
+			if(player.mind in predators)
+				predators -= player
+			if(player.mind in xenomorphs)
+				xenomorphs -= player
+			if(player.mind in survivors)
+				survivors -= player
+			var/datum/mind/new_queen = player.mind
+			if(!(new_queen in xenomorphs))
+				transform_queen(new_queen)
 
 /datum/game_mode/proc/check_xeno_late_join(mob/xeno_candidate)
 	if(jobban_isbanned(xeno_candidate, "Alien")) // User is jobbanned
@@ -465,6 +476,24 @@ datum/game_mode/proc/initialize_special_clamps()
 
 	if(original) cdel(original) //Just to be sure.
 
+/datum/game_mode/proc/transform_queen(datum/mind/ghost_mind)
+	var/mob/original = ghost_mind.current
+	var/mob/living/carbon/Xenomorph/new_queen
+	var/datum/hive_status/hive = hive_datum[XENO_HIVE_NORMAL]
+	if(!hive.living_xeno_queen && original && original.client && original.client.prefs && (original.client.prefs.be_special & BE_QUEEN) && !jobban_isbanned(original, "Queen"))
+		new_queen = new /mob/living/carbon/Xenomorph/Queen (pick(xeno_spawn))
+	else
+		return
+	ghost_mind.transfer_to(new_queen)
+	ghost_mind.name = ghost_mind.current.name
+
+	to_chat(new_queen, "<B>You are now the alien queen!</B>")
+	to_chat(new_queen, "<B>Your job is to spread the hive.</B>")
+	to_chat(new_queen, "Talk in Hivemind using <strong>;</strong> (e.g. ';My life for the hive!')")
+
+	new_queen.update_icons()
+
+	if(original) cdel(original) //Just to be sure.
 
 //===================================================\\
 

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -90,8 +90,7 @@ Additional game mode variables.
 
 datum/game_mode/proc/initialize_special_clamps()
 	var/ready_players = num_players() // Get all players that have "Ready" selected
-	//xeno_starting_num = max((ready_players/7), xeno_required_num) //(n, minimum, maximum)
-	xeno_starting_num = 10
+	xeno_starting_num = max((ready_players/7), xeno_required_num) //(n, minimum, maximum)
 	surv_starting_num = CLAMP((ready_players/25), 0, 8)
 	merc_starting_num = max((ready_players/3), 1)
 	marine_starting_num = ready_players - xeno_starting_num - surv_starting_num - merc_starting_num
@@ -290,11 +289,14 @@ datum/game_mode/proc/initialize_special_clamps()
 		if(A.assigned_role == "MODE")
 			message_admins("DEBUG: Assigned role mode?")
 			possible_xenomorphs -= A
+		if(A == queen)
+			message_admins("DEBUG: Queen also has xeno on, removing them..")
+			possible_xenomorphs -= A
 
 	for(var/datum/mind/A in possible_xenomorphs)
 		message_admins("Xenomorph possible candidate: [A]")
 
-	var/i = 10
+	var/i = xeno_starting_num
 	var/datum/mind/new_xeno
 	var/turf/larvae_spawn
 	message_admins("DEBUG: [i] this is i.")

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -294,15 +294,16 @@ datum/game_mode/proc/initialize_special_clamps()
 			possible_xenomorphs -= A
 
 	for(var/datum/mind/A in possible_xenomorphs)
-		message_admins("Xenomorph possible candidate: [A]")
+		message_admins("DEBUG: Xenomorph possible candidate: [A.key]")
 
 	var/i = xeno_starting_num
 	var/datum/mind/new_xeno
 	var/turf/larvae_spawn
+	message_admins("DEBUG: [xeno_starting_num]")
 	message_admins("DEBUG: [i] this is i.")
 	while(i > 0) //While we can still pick someone for the role.
 		if(possible_xenomorphs.len) //We still have candidates
-			message_admins("We still have candidates, yay.")
+			message_admins("DEBUG: We still have candidates, yay.")
 			new_xeno = pick(possible_xenomorphs)
 			if(!new_xeno) 
 				message_admins("DEBUG: Last candidate gone, aborting.")
@@ -324,7 +325,7 @@ datum/game_mode/proc/initialize_special_clamps()
 	So they may have been removed from the list, oh well.
 	*/
 	for(var/datum/mind/A in xenomorphs)
-		message_admins("Xenomorph picked candidate: [A]")
+		message_admins("Xenomorph picked candidate: [A.key]")
 	if(xenomorphs.len < xeno_required_num)
 		//to_chat(world, "<h2 style=\"color:red\">Could not find any candidates after initial alien list pass. <b>Aborting</b>.</h2>")
 		message_admins("Xenomorph list didn't get properly filled.")

--- a/code/game/gamemodes/cm_initialize.dm
+++ b/code/game/gamemodes/cm_initialize.dm
@@ -329,10 +329,8 @@ datum/game_mode/proc/initialize_special_clamps()
 		if(!jobban_isbanned(new_queen.current))
 			new_queen.assigned_role = "MODE"
 			new_queen.special_role = "Xenomorph"
-			if(new_queen in xenomorphs)
-				xenomorphs -= new_queen
-				message_admins("DEBUG: Player also has xeno preference on, removing from xeno list.")
 			queen = new_queen
+			message_admins("DEBUG:Queen candidate picked.")
 			break
 
 	return TRUE
@@ -342,11 +340,11 @@ datum/game_mode/proc/initialize_special_clamps()
 		if(new_xeno != queen)
 			transform_xeno(new_xeno)
 		else
-			message_admins("Queen wasn't removed from xeno list properly.")
+			message_admins("DEBUG:Queen also had xeno on, not picking them as xeno.")
 
 datum/game_mode/proc/initialize_post_queen_list()
 	if(!queen)
-		message_admins("No queen candidate picked, returning.")
+		message_admins("DEBUG:No queen candidate picked, returning.")
 		return
 	transform_queen(queen)
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -13,7 +13,7 @@
 /datum/game_mode/colonialmarines/can_start()
 	initialize_special_clamps()
 	initialize_starting_predator_list()
-	if(!initialize_starting_xenomorph_list() && !initialize_starting_queen_list())
+	if(!initialize_starting_queen_list() && !initialize_starting_xenomorph_list())
 		return FALSE
 	initialize_starting_survivor_list()
 	return TRUE

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -11,12 +11,12 @@
 
 /* Pre-pre-startup */
 /datum/game_mode/colonialmarines/can_start()
+	. = TRUE
 	initialize_special_clamps()
 	initialize_starting_predator_list()
-	if(!initialize_starting_xenomorph_list())
-		return
+	if(!initialize_starting_queen_list() || !initialize_starting_xenomorph_list())
+		. = FALSE
 	initialize_starting_survivor_list()
-	return 1
 
 /datum/game_mode/colonialmarines/announce()
 	to_chat(world, "<span class='round_header'>The current map is - [map_tag]!</span>")
@@ -128,6 +128,7 @@
 //Xenos and survivors should not spawn anywhere until we transform them.
 /datum/game_mode/colonialmarines/post_setup()
 	initialize_post_predator_list()
+	initialize_post_queen_list()
 	initialize_post_xenomorph_list()
 	initialize_post_survivor_list()
 	initialize_post_marine_gear_list()

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -14,7 +14,7 @@
 	. = TRUE
 	initialize_special_clamps()
 	initialize_starting_predator_list()
-	if(!initialize_starting_queen_list() || !initialize_starting_xenomorph_list())
+	if(!initialize_starting_xenomorph_list() || !initialize_starting_queen_list())
 		. = FALSE
 	initialize_starting_survivor_list()
 

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -11,9 +11,9 @@
 
 /* Pre-pre-startup */
 /datum/game_mode/colonialmarines/can_start()
+	initialize_special_clamps()
 	var/found_queen = initialize_starting_queen_list()
 	var/found_xenos = initialize_starting_xenomorph_list()
-	initialize_special_clamps()
 	initialize_starting_predator_list()
 	if(!found_queen && !found_xenos)
 		message_admins("DEBUG: No queen or xeno candidates found.")

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -3,7 +3,7 @@
 	config_tag = "Distress Signal"
 	required_players = 1 //Need at least one player, but really we need 2.
 	xeno_required_num = 1 //Need at least one xeno.
-	monkey_amount = 25
+	monkey_amount = 5
 	flags_round_type = MODE_INFESTATION|MODE_FOG_ACTIVATED
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -82,6 +82,12 @@
 			if(MAP_PRISON_STATION) new /obj/item/map/FOP_map(T)
 
 	if(monkey_amount)
+		var/playerC = 0
+		for(var/mob/new_player/player in player_list)
+			if((player.client)&&(player.ready))
+				playerC++
+		var/scale = max(playerC / MARINE_GEAR_SCALING_NORMAL, 1)
+		monkey_amount = round(scale * monkey_amount)
 		//var/debug_tally = 0
 		switch(map_tag)
 			if(MAP_LV_624) monkey_types = list(/mob/living/carbon/monkey, /mob/living/carbon/monkey/tajara, /mob/living/carbon/monkey/unathi, /mob/living/carbon/monkey/skrell)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -11,12 +11,12 @@
 
 /* Pre-pre-startup */
 /datum/game_mode/colonialmarines/can_start()
-	. = TRUE
 	initialize_special_clamps()
 	initialize_starting_predator_list()
-	if(!initialize_starting_xenomorph_list() || !initialize_starting_queen_list())
-		. = FALSE
+	if(!initialize_starting_xenomorph_list() && !initialize_starting_queen_list())
+		return FALSE
 	initialize_starting_survivor_list()
+	return TRUE
 
 /datum/game_mode/colonialmarines/announce()
 	to_chat(world, "<span class='round_header'>The current map is - [map_tag]!</span>")
@@ -84,7 +84,7 @@
 	if(monkey_amount)
 		var/playerC = 0
 		for(var/mob/new_player/player in player_list)
-			if((player.client)&&(player.ready))
+			if(player.client && player.ready)
 				playerC++
 		var/scale = max(playerC / MARINE_GEAR_SCALING_NORMAL, 1)
 		monkey_amount = round(scale * monkey_amount)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -14,6 +14,7 @@
 	initialize_special_clamps()
 	initialize_starting_predator_list()
 	if(!initialize_starting_queen_list() && !initialize_starting_xenomorph_list())
+		message_admins("DEBUG:Failed to find anyone with either queen or xeno pref on.")
 		return FALSE
 	initialize_starting_survivor_list()
 	return TRUE

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -11,10 +11,12 @@
 
 /* Pre-pre-startup */
 /datum/game_mode/colonialmarines/can_start()
+	var/found_queen = initialize_starting_queen_list()
+	var/found_xenos = initialize_starting_xenomorph_list()
 	initialize_special_clamps()
 	initialize_starting_predator_list()
-	if(!(initialize_starting_queen_list() || initialize_starting_xenomorph_list()))
-		message_admins("DEBUG:Failed to find anyone with either queen or xeno pref on.")
+	if(!found_queen && !found_xenos)
+		message_admins("DEBUG: No queen or xeno candidates found.")
 		return FALSE
 	initialize_starting_survivor_list()
 	return TRUE

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -13,8 +13,11 @@
 /datum/game_mode/colonialmarines/can_start()
 	initialize_special_clamps()
 	initialize_starting_predator_list()
-	if(!initialize_starting_queen_list() && !initialize_starting_xenomorph_list())
-		message_admins("DEBUG:Failed to find anyone with either queen or xeno pref on.")
+	if(!initialize_starting_queen_list())
+		message_admins("DEBUG:Failed to find anyone with either queen pref on.")
+		return FALSE
+	if(!initialize_starting_xenomorph_list())
+		message_admins("DEBUG:Failed to find anyone with xeno pref on.")
 		return FALSE
 	initialize_starting_survivor_list()
 	return TRUE

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -89,7 +89,7 @@
 		for(var/mob/new_player/player in player_list)
 			if(player.client && player.ready)
 				playerC++
-		var/scale = max(playerC / MARINE_GEAR_SCALING_NORMAL, 1)
+		var/scale = max((playerC / MARINE_GEAR_SCALING_NORMAL), 1)
 		monkey_amount = round(scale * monkey_amount)
 		//var/debug_tally = 0
 		switch(map_tag)

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -12,9 +12,9 @@
 /* Pre-pre-startup */
 /datum/game_mode/colonialmarines/can_start()
 	initialize_special_clamps()
+	initialize_starting_predator_list()
 	var/found_queen = initialize_starting_queen_list()
 	var/found_xenos = initialize_starting_xenomorph_list()
-	initialize_starting_predator_list()
 	if(!found_queen && !found_xenos)
 		return FALSE
 	initialize_starting_survivor_list()

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -13,11 +13,8 @@
 /datum/game_mode/colonialmarines/can_start()
 	initialize_special_clamps()
 	initialize_starting_predator_list()
-	if(!initialize_starting_queen_list())
-		message_admins("DEBUG:Failed to find anyone with either queen pref on.")
-		return FALSE
-	if(!initialize_starting_xenomorph_list())
-		message_admins("DEBUG:Failed to find anyone with xeno pref on.")
+	if(!(initialize_starting_queen_list() || initialize_starting_xenomorph_list()))
+		message_admins("DEBUG:Failed to find anyone with either queen or xeno pref on.")
 		return FALSE
 	initialize_starting_survivor_list()
 	return TRUE

--- a/code/game/gamemodes/colonialmarines/colonialmarines.dm
+++ b/code/game/gamemodes/colonialmarines/colonialmarines.dm
@@ -16,7 +16,6 @@
 	var/found_xenos = initialize_starting_xenomorph_list()
 	initialize_starting_predator_list()
 	if(!found_queen && !found_xenos)
-		message_admins("DEBUG: No queen or xeno candidates found.")
 		return FALSE
 	initialize_starting_survivor_list()
 	return TRUE


### PR DESCRIPTION
-Queen is now rolled before xeno from everyone who has queen on, instead of just the available xenos.
-Amount of starting monkeys reduced to 5, scales with player population like the requisition vendors.