### PR TITLE
HOTFIX: Eliminated Ancient Upgrade Thresholds

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/XenoUpgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoUpgrade.dm
@@ -489,7 +489,6 @@ Queen		 0.0	 0.1	 0.2	 0.3
 					maxHealth = 300
 					plasma_gain = 15
 					plasma_max = 200
-					upgrade_threshold = 800
 					caste_desc = "An unstoppable force that remains when others would fall."
 					speed = -0.4
 					armor_deflection = 30
@@ -504,7 +503,6 @@ Queen		 0.0	 0.1	 0.2	 0.3
 					maxHealth = 265
 					plasma_gain = 8
 					plasma_max = 100
-					upgrade_threshold = 1600
 					caste_desc = "An hulking beast capable of effortlessly breaking and tearing through its enemies."
 					speed = -0.5
 					armor_deflection = 55

--- a/code/modules/mob/living/carbon/xenomorph/XenoUpgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoUpgrade.dm
@@ -456,6 +456,7 @@ Queen		 0.0	 0.1	 0.2	 0.3
 					tacklemax = 5
 					tackle_damage = 40 // Prior was 30
 					pounce_delay = 30
+				if("Hunter")
 					to_chat(src, "<span class='xenoannounce'>You are the epitome of the hunter. Few can stand against you in open combat.</span>")
 					melee_damage_lower = 40
 					melee_damage_upper = 50


### PR DESCRIPTION
Eliminated problematic upgrade thresholds for Ancient Hunters and Defenders; likely copy pasta gone wrong.