### PR TITLE
Mentor Rework [W.I.P.]

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -18,7 +18,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_view_range,		/*changes how far we can see*/
 	/client/proc/getserverlogs,		/*for accessing server logs*/
 	/client/proc/getcurrentlogs,		/*for accessing server logs for the current round*/
-	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
+	/client/proc/cmd_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
 	/client/proc/cmd_admin_subtle_message,	/*send an message to somebody as a 'voice in their head'*/
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
@@ -233,7 +233,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/remove_players_from_vic
 	)
 var/list/admin_verbs_mod = list(
-	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
+	/client/proc/cmd_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
 	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game.*/
 	/client/proc/toggledebuglogs,
@@ -267,19 +267,14 @@ var/list/admin_verbs_mod = list(
 )
 
 var/list/admin_verbs_mentor = list(
-	/client/proc/cmd_admin_pm_context,
-	/client/proc/cmd_admin_pm_panel,
-	/datum/admins/proc/player_notes_list,
-	/datum/admins/proc/player_notes_show,
+	/client/proc/cmd_pm_context,
+	/client/proc/cmd_mentor_pm_panel,
 	/client/proc/admin_ghost,
 	/client/proc/cmd_mod_say,
-	/client/proc/dsay,
-	/datum/admins/proc/togglesleep,
 	/client/proc/cmd_admin_subtle_message,
 	/datum/admins/proc/viewUnheardMhelps,
 	/datum/admins/proc/viewUnheardAhelps,
-	/datum/admins/proc/viewCLFaxes,
-	/datum/admins/proc/viewUSCMFaxes
+	/datum/admins/proc/viewCLFaxes
 )
 
 /client/proc/add_admin_verbs()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -80,7 +80,8 @@
 		var/task = href_list["editrights"]
 		if(task == "add")
 			var/new_ckey = ckey(input(usr,"New admin's ckey","Admin ckey", null) as text|null)
-			if(!new_ckey)	return
+			if(!new_ckey)	
+				return
 			if(new_ckey in admin_datums)
 				to_chat(usr, "<font color='red'>Error: Topic 'editrights': [new_ckey] is already an admin</font>")
 				return
@@ -2470,7 +2471,29 @@
 		player_notes_copy(key)
 		return
 
-	if(href_list["mark"])
+	if(href_list["mmark"])
+		var/mob/ref_person = locate(href_list["mark"])
+		if(!istype(ref_person))
+			to_chat(usr, "\blue Looks like that person stopped existing!")
+			return
+		if(ref_person && ref_person.adminhelp_marked)
+			to_chat(usr, "<b>This Pray/Mentorhelp/Adminhelp is already being handled.</b>")
+			usr << sound('sound/effects/adminhelp-error.ogg')
+			return
+
+		message_staff("[usr.key] has used 'Mark' on the Mentorhelp from [key_name_admin(ref_person)] and is preparing to respond...", 1)
+		var/msgplayer = "\blue <b>NOTICE: <font color=red>[usr.key]</font> has marked your request and is preparing to respond...</b>"
+
+		to_chat(ref_person, msgplayer)
+
+		unansweredMhelps.Remove(ref_person.computer_id) //It has been answered so take it off of the unanswered list
+		viewUnheardMhelps() //This SHOULD refresh the page
+
+		ref_person.adminhelp_marked = 1 //Timer to prevent multiple clicks
+		spawn(1000) //This should be <= the Adminhelp cooldown in adminhelp.dm
+			if(ref_person)	ref_person.adminhelp_marked = 0
+
+	if(href_list["amark"])
 		var/mob/ref_person = locate(href_list["mark"])
 		if(!istype(ref_person))
 			to_chat(usr, "\blue Looks like that person stopped existing!")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2476,8 +2476,8 @@
 		if(!istype(ref_person))
 			to_chat(usr, "\blue Looks like that person stopped existing!")
 			return
-		if(ref_person && ref_person.adminhelp_marked)
-			to_chat(usr, "<b>This Pray/Mentorhelp/Adminhelp is already being handled.</b>")
+		if(ref_person && ref_person.client.mentorhelp_marked)
+			to_chat(usr, "<b>This Mentorhelp is already being handled.</b>")
 			usr << sound('sound/effects/adminhelp-error.ogg')
 			return
 
@@ -2489,40 +2489,38 @@
 		unansweredMhelps.Remove(ref_person.computer_id) //It has been answered so take it off of the unanswered list
 		viewUnheardMhelps() //This SHOULD refresh the page
 
-		ref_person.adminhelp_marked = 1 //Timer to prevent multiple clicks
-		spawn(1000) //This should be <= the Adminhelp cooldown in adminhelp.dm
-			if(ref_person)	ref_person.adminhelp_marked = 0
+		ref_person.client.mentorhelp_marked = 1 //Timer to prevent multiple clicks
+		spawn(600) //This should be <= the Adminhelp cooldown in adminhelp.dm
+			if(ref_person)	ref_person.client.mentorhelp_marked = 0
 
 	if(href_list["amark"])
-		var/mob/ref_person = locate(href_list["mark"])
+		var/mob/ref_person = locate(href_list["amark"])
 		if(!istype(ref_person))
 			to_chat(usr, "\blue Looks like that person stopped existing!")
 			return
-		if(ref_person && ref_person.adminhelp_marked)
-			to_chat(usr, "<b>This Pray/Mentorhelp/Adminhelp is already being handled.</b>")
+		if(ref_person && ref_person.client.adminhelp_marked)
+			to_chat(usr, "<b>This Adminhelp is already being handled.</b>")
 			usr << sound('sound/effects/adminhelp-error.ogg')
 			return
 
-		message_staff("[usr.key] has used 'Mark' on the Pray/Mentorhelp/Adminhelp from [key_name_admin(ref_person)] and is preparing to respond...", 1)
+		message_admins("[usr.key] has used 'Mark' on the Adminhelp from [key_name_admin(ref_person)] and is preparing to respond...", 1)
 		var/msgplayer = "\blue <b>NOTICE: <font color=red>[usr.key]</font> has marked your request and is preparing to respond...</b>"
 
 		to_chat(ref_person, msgplayer)
 
-		unansweredMhelps.Remove(ref_person.computer_id)
 		unansweredAhelps.Remove(ref_person.computer_id) //It has been answered so take it off of the unanswered list
-		viewUnheardMhelps() //This SHOULD refresh the page
-		viewUnheardAhelps()
+		viewUnheardAhelps()//This SHOULD refresh the page
 
-		ref_person.adminhelp_marked = 1 //Timer to prevent multiple clicks
-		spawn(1000) //This should be <= the Adminhelp cooldown in adminhelp.dm
-			if(ref_person)	ref_person.adminhelp_marked = 0
+		ref_person.client.adminhelp_marked = 1 //Timer to prevent multiple clicks
+		spawn(1200) //This should be <= the Adminhelp cooldown in adminhelp.dm
+			if(ref_person)	ref_person.client.adminhelp_marked = 0
 
 	if(href_list["noresponse"])
 		var/mob/ref_person = locate(href_list["noresponse"])
 		if(!istype(ref_person))
 			to_chat(usr, "\blue Looks like that person stopped existing!")
 			return
-		if(ref_person && ref_person.adminhelp_marked)
+		if(ref_person && ref_person.client.adminhelp_marked)
 			to_chat(usr, "<b>This Pray/Mentorhelp/Adminhelp is already being handled.</b>")
 			usr << sound('sound/effects/adminhelp-error.ogg')
 			return
@@ -2538,16 +2536,16 @@
 		viewUnheardMhelps() //This SHOULD refresh the page
 		viewUnheardAhelps()
 
-		ref_person.adminhelp_marked = 1 //Timer to prevent multiple clicks
+		ref_person.client.adminhelp_marked = 1 //Timer to prevent multiple clicks
 		spawn(1000) //This should be <= the Adminhelp cooldown in adminhelp.dm
-			if(ref_person)	ref_person.adminhelp_marked = 0
+			if(ref_person)	ref_person.client.adminhelp_marked = 0
 
 	if(href_list["warning"])
 		var/mob/ref_person = locate(href_list["warning"])
 		if(!istype(ref_person))
 			to_chat(usr, "\blue Looks like that person stopped existing!")
 			return
-		if(ref_person && ref_person.adminhelp_marked)
+		if(ref_person && ref_person.client.adminhelp_marked)
 			to_chat(usr, "<b>This Pray/Mentorhelp/Adminhelp is already being handled.</b>")
 			usr << sound('sound/effects/adminhelp-error.ogg')
 			return
@@ -2564,16 +2562,16 @@
 		src.viewUnheardMhelps() //This SHOULD refresh the page
 		src.viewUnheardAhelps()
 
-		ref_person.adminhelp_marked = 1 //Timer to prevent multiple clicks
+		ref_person.client.adminhelp_marked = 1 //Timer to prevent multiple clicks
 		spawn(1000) //This should be <= the Adminhelp cooldown in adminhelp.dm
-			if(ref_person)	ref_person.adminhelp_marked = 0
+			if(ref_person)	ref_person.client.adminhelp_marked = 0
 
 	if(href_list["autoresponse"]) // new verb on the Ahelp.  Will tell the person their message was received, and they probably won't get a response
 		var/mob/ref_person = locate(href_list["autoresponse"])
 		if(!istype(ref_person))
 			to_chat(usr, "\blue Looks like that person stopped existing!")
 			return
-		if(ref_person && ref_person.adminhelp_marked)
+		if(ref_person && ref_person.client.adminhelp_marked)
 			to_chat(usr, "<b>This Mentorhelp/Adminhelp is already being handled, but continue if you wish.</b>")
 			usr << sound('sound/effects/adminhelp-error.ogg')
 			if(alert(usr, "Are you sure you want to autoreply to this marked Mentorhelp/Adminhelp?", "Confirmation", "Yes", "No") != "Yes")
@@ -2623,9 +2621,9 @@
 		unansweredAhelps.Remove(ref_person.computer_id) //It has been answered so take it off of the unanswered list
 		src.viewUnheardAhelps() //This SHOULD refresh the page
 
-		ref_person.adminhelp_marked = 1 //Timer to prevent multiple clicks
+		ref_person.client.adminhelp_marked = 1 //Timer to prevent multiple clicks
 		spawn(1000) //This should be <= the Adminhelp cooldown in adminhelp.dm
-			if(ref_person)	ref_person.adminhelp_marked = 0
+			if(ref_person)	ref_person.client.adminhelp_marked = 0
 
 
 	if(href_list["ccmark"]) // CentComm-mark. We want to let all Admins know that something is "Marked", but not let the player know because it's not very RP-friendly.

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -161,13 +161,13 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 
 	var/msg = input("Please enter your message:", "Mentor Help", null, null) as message|null
 
-	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
+	if(src.handle_spam_prevention(msg, MUTE_ADMINHELP))
 		return
 
 	//clean the input msg
 	if(!msg)	
 		return
-	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
+	msg = sanitize(copytext(msg, 1, MAX_MESSAGE_LEN))
 	
 	if(!msg)	
 		return
@@ -177,7 +177,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	if(!mob)	
 		return
 
-	var/mentor_msg = "<br><br><font color='#009900'><b>MENTORHELP: [get_options_bar(mob, 4, 1, 1, 0)]:</b></font> <br><font color='#DA6200'><b>[msg]</font></b><br>"
+	var/mentor_msg = "<br><br><font color='#009900'><b>MENTORHELP: [get_options_bar(mob, 4, 0, 1, 0)]:</b></font> <br><font color='#DA6200'><b>[msg]</font></b><br>"
 	msg = "<br><br><font color='#009900'><b>MENTORHELP: [get_options_bar(mob, 2, 1, 1, 1)]:</b></font> <br><font color='#DA6200'><b>[msg]</font></b><br>"
 
 	var/admin_number_afk = 0

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -1,21 +1,33 @@
 //allows right clicking mobs to send an admin PM to their client, forwards the selected mob's client to cmd_admin_pm
-/client/proc/cmd_admin_pm_context(mob/M as mob in mob_list)
+/client/proc/cmd_pm_context(mob/M as mob in mob_list)
 	set category = null
-	set name = "Admin PM Mob"
+	set name = "PM Mob"
+
 	if(!holder)
-		to_chat(src, "<font color='red'>Error: Admin-PM-Context: Only administrators may use this command.</font>")
+		to_chat(src, "<font color='red'>Error: Only administrators may use this command.</font>")
 		return
-	if( !ismob(M) || !M.client )	return
-	cmd_admin_pm(M.client,null)
-	feedback_add_details("admin_verb","APMM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+	if(!ismob(M) || !M.client)
+		to_chat(src, "<font color='red'>Error: Mob has no client.</font>")
+		return
+
+	if(holder.rights & R_ADMIN)
+		cmd_admin_pm(M.client, null)
+	else
+		cmd_mentor_pm(M.client, null)
+
+	feedback_add_details("admin_verb","PMC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 
 //shows a list of clients we could send PMs to, then forwards our choice to cmd_admin_pm
 /client/proc/cmd_admin_pm_panel()
 	set category = "Admin"
 	set name = "Admin PM"
+
 	if(!holder)
-		to_chat(src, "<font color='red'>Error: Admin-PM-Panel: Only administrators may use this command.</font>")
+		to_chat(src, "<font color='red'>Error: Only administrators may use this command.</font>")
 		return
+
 	var/list/client/targets[0]
 	for(var/client/T)
 		if(T.mob)
@@ -27,60 +39,86 @@
 				targets["[T.mob.real_name](as [T.mob.name]) - [T]"] = T
 		else
 			targets["(No Mob) - [T]"] = T
+
 	var/list/sorted = sortList(targets)
-	var/target = input(src,"To whom shall we send a message?","Admin PM",null) in sorted|null
+	var/target = input(src,"Who do you want to PM?","Admin PM",null) in sorted|null
+
 	cmd_admin_pm(targets[target],null)
 	feedback_add_details("admin_verb","APM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+//shows a list of clients we could send PMs to, then forwards our choice to cmd_admin_pm
+/client/proc/cmd_mentor_pm_panel()
+	set category = "Admin"
+	set name = "Mentor PM"
+
+	if(!holder)
+		to_chat(src, "<font color='red'>Error: Only administrators may use this command.</font>")
+		return
+
+	var/list/client/targets[0]
+	for(var/client/T)
+		targets["[T]"] = T
+
+	var/list/sorted = sortList(targets)
+	var/target = input(src,"Who do you want to PM?","Mentor PM",null) in sorted|null
+
+	cmd_admin_pm(targets[target],null)
+	feedback_add_details("admin_verb","MPM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
 //takes input from cmd_admin_pm_context, cmd_admin_pm_panel or /client/Topic and sends them a PM.
 //Fetching a message if needed. src is the sender and C is the target client
-
-/client/proc/cmd_admin_pm(var/client/C, var/msg = null)
+/client/proc/cmd_mentor_pm(var/client/C, var/msg = null)
 	if(prefs.muted & MUTE_ADMINHELP)
-		to_chat(src, "<font color='red'>Error: Private-Message: You are unable to use PMs (muted).</font>")
+		to_chat(src, "<font color='red'>Error: You are unable to use admin PMs (muted).</font>")
 		return
 
 	if(!istype(C,/client))
-		if(holder)	to_chat(src, "<font color='red'>Error: Private-Message: Client not found.</font>")
-		else		to_chat(src, "<font color='red'>Error: Private-Message: Client not found. They may have lost connection, so try using an adminhelp!</font>")
+		if(holder)	
+			to_chat(src, "<font color='red'>Error: Client not found.</font>")
+		else		
+			to_chat(src, "<font color='red'>Error: Client not found. They may have lost connection, so try using sending a new mentorhelp!</font>")
 		return
 
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
 		msg = input(src,"Message:", "Private message to [key_name(C, 0, holder ? 1 : 0)]") as message|null
 
-		if(!msg)	return
-		if(!C)
-			if(holder)	to_chat(src, "<font color='red'>Error: Admin-PM: Client not found.</font>")
-			else		to_chat(src, "<font color='red'>Error: Private-Message: Client not found. They may have lost connection, so try using an adminhelp!</font>")
+		if(!msg)	
 			return
 
-	if (src.handle_spam_prevention(msg,MUTE_ADMINHELP))
+		if(!C)
+			if(holder)	
+				to_chat(src, "<font color='red'>Error: Client not found.</font>")
+			else		
+				to_chat(src, "<font color='red'>Error: Client not found. They may have lost connection, so try using sending a new mentorhelp!</font>")
+			return
+
+	if(src.handle_spam_prevention(msg, MUTE_ADMINHELP))
 		return
 
 	//clean the message if it's not sent by a high-rank admin
-	if(!check_rights(R_SERVER|R_DEBUG,0))
-		msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
-		if(!msg)	return
+	if(!check_rights(R_SERVER|R_DEBUG, 0))
+		msg = sanitize(copytext(msg, 1, MAX_MESSAGE_LEN))
+		if(!msg)	
+			return
 
 	var/recieve_color = "purple"
 	var/send_pm_type = " "
 	var/recieve_pm_type = "Player"
 
 
-	if(holder)
-		//PMs sent from admins and mods display their rank
-		if(holder)
-			recieve_color = "#009900"
-			send_pm_type = holder.rank + " "
-			if(!C.holder && holder && holder.fakekey)
-				recieve_pm_type = "Admin"
-			else
-				recieve_pm_type = holder.rank
+	if(holder) //PMs sent from admins and mods display their rank
+		recieve_color = "#009900"
+		send_pm_type = holder.rank + " "
+
+		if(!C.holder && holder && holder.fakekey)
+			recieve_pm_type = "Admin"
+		else
+			recieve_pm_type = holder.rank
 
 	else if(!C.holder)
-		to_chat(src, "<font color='red'>Error: Admin-PM: Non-admin to non-admin PM communication is forbidden.</font>")
+		to_chat(src, "<font color='red'>Error: Only administrators may use this command.</font>")
 		return
 
 	var/recieve_message = ""
@@ -113,7 +151,7 @@
 	if(C.prefs && C.prefs.toggles_sound & SOUND_ADMINHELP)
 		C << 'sound/effects/adminhelp-reply.ogg'
 
-	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")
+	log_admin("Mentor PM: [key_name(src)]->[key_name(C)]: [msg]")
 
 	//we don't use message_admins here because the sender/receiver might get it too
 	for(var/client/X in admins)
@@ -121,4 +159,98 @@
 		if(X == C || X == src)
 			continue
 		if(X.key!=key && X.key!=C.key && (X.holder.rights & R_ADMIN) || (X.holder.rights & (R_MOD|R_MENTOR)) )
-			to_chat(X, "<B><font color='blue'>PM: [key_name(src, X, 0)]-&gt;[key_name(C, X, 0)]:</B> \blue [msg]</font>")
+			to_chat(X, "<B><font color='blue'>Mentor PM: [key_name(src, X, 0)]-&gt;[key_name(C, X, 0)]:</B> \blue [msg]</font>")
+
+
+/client/proc/cmd_admin_pm(var/client/C, var/msg = null)
+	if(prefs.muted & MUTE_ADMINHELP)
+		to_chat(src, "<font color='red'>Error: You are unable to use admin PMs (muted).</font>")
+		return
+
+	if(!istype(C,/client))
+		if(holder)	
+			to_chat(src, "<font color='red'>Error: Client not found.</font>")
+		else		
+			to_chat(src, "<font color='red'>Error: Client not found. They may have lost connection, so try using sending a new adminhelp!</font>")
+		return
+
+	//get message text, limit it's length.and clean/escape html
+	if(!msg)
+		msg = input(src,"Message:", "Private message to [key_name(C, 0, holder ? 1 : 0)]") as message|null
+
+		if(!msg)	
+			return
+
+		if(!C)
+			if(holder)	
+				to_chat(src, "<font color='red'>Error: Client not found.</font>")
+			else		
+				to_chat(src, "<font color='red'>Error: Client not found. They may have lost connection, so try using sending a new adminhelp!</font>")
+			return
+
+	if(src.handle_spam_prevention(msg, MUTE_ADMINHELP))
+		return
+
+	//clean the message if it's not sent by a high-rank admin
+	if(!check_rights(R_SERVER|R_DEBUG, 0))
+		msg = sanitize(copytext(msg, 1, MAX_MESSAGE_LEN))
+		if(!msg)	
+			return
+
+	var/recieve_color = "purple"
+	var/send_pm_type = " "
+	var/recieve_pm_type = "Player"
+
+
+	if(holder) //PMs sent from admins and mods display their rank
+		recieve_color = "#009900"
+		send_pm_type = holder.rank + " "
+
+		if(!C.holder && holder && holder.fakekey)
+			recieve_pm_type = "Admin"
+		else
+			recieve_pm_type = holder.rank
+
+	else if(!C.holder)
+		to_chat(src, "<font color='red'>Error: Only administrators may use this command.</font>")
+		return
+
+	var/recieve_message = ""
+
+	if(holder && !C.holder)
+		recieve_message = "<font color='[recieve_color]'><b>-- Click the [recieve_pm_type]'s name to reply --</b></font>\n"
+		if(C.adminhelped)
+			to_chat(C, recieve_message)
+			C.adminhelped = 0
+
+		//AdminPM popup for ApocStation and anybody else who wants to use it. Set it with POPUP_ADMIN_PM in config.txt ~Carn
+		if(config.popup_admin_pm)
+			spawn(0)	//so we don't hold the caller proc up
+				var/sender = src
+				var/sendername = key
+				var/reply = input(C, msg,"[recieve_pm_type] PM from-[sendername]", "") as text|null		//show message and await a reply
+				if(C && reply)
+					if(sender)
+						C.cmd_admin_pm(sender,reply)										//sender is still about, let's reply to them
+					else
+						adminhelp(reply)													//sender has left, adminhelp instead
+				return
+
+	recieve_message = "<br><br><font color='[recieve_color]'><b>[recieve_pm_type] PM from [get_options_bar(src, C.holder ? 1 : 0, C.holder ? 1 : 0, 1)]: <font color='#DA6200'>[msg]</b></font><br>"
+	to_chat(C, recieve_message)
+	to_chat(src, "<br><br><font color='#009900'><b>[send_pm_type]PM to [get_options_bar(C, holder ? 1 : 0, holder ? 1 : 0, 1)]: <font color='#DA6200'>[msg]</b></font><br>")
+
+	//play the recieving admin the adminhelp sound (if they have them enabled)
+	//non-admins shouldn't be able to disable this
+	if(C.prefs && C.prefs.toggles_sound & SOUND_ADMINHELP)
+		C << 'sound/effects/adminhelp-reply.ogg'
+
+	log_admin("Admin PM: [key_name(src)]->[key_name(C)]: [msg]")
+
+	//we don't use message_admins here because the sender/receiver might get it too
+	for(var/client/X in admins)
+		//check client/X is an admin and isn't the sender or recipient
+		if(X == C || X == src)
+			continue
+		if(X.key!=key && X.key!=C.key && (X.holder.rights & R_ADMIN))
+			to_chat(X, "<B><font color='blue'>Admin PM: [key_name(src, X, 0)]-&gt;[key_name(C, X, 0)]:</B> \blue [msg]</font>")

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -2,10 +2,12 @@
 	set category = "Special Verbs"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN))	
+		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
-	if(!msg)	return
+	if(!msg)	
+		return
 
 	mob.log_talk(msg, LOG_ASAY)
 

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -2,11 +2,14 @@
 	set category = "Special Verbs"
 	set name = "Dsay" //Gave this shit a shorter name so you only have to time out "dsay" rather than "dead say" to use it --NeoFite
 	set hidden = 1
-	if(!src.holder)
+
+	if(src.holder.rights & (R_ADMIN|R_MOD))
 		to_chat(src, "Only administrators may use this command.")
 		return
+
 	if(!src.mob)
 		return
+
 	if(prefs.muted & MUTE_DEADCHAT)
 		to_chat(src, "\red You cannot send DSAY messages (muted).")
 		return
@@ -15,7 +18,7 @@
 		to_chat(src, "\red You have deadchat muted.")
 		return
 
-	if (src.handle_spam_prevention(msg,MUTE_DEADCHAT))
+	if(src.handle_spam_prevention(msg, MUTE_DEADCHAT))
 		return
 
 	var/stafftype = null
@@ -25,13 +28,13 @@
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	mob.log_talk(msg, LOG_DSAY)
 
-	if (!msg)
+	if(!msg)
 		return
 
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[stafftype]([src.holder.fakekey ? pick("BADMIN", "hornigranny", "TLF", "scaredforshadows", "KSI", "Silnazi", "HerpEs", "BJ69", "SpoofedEdd", "Uhangay", "Wario90900", "Regarity", "MissPhareon", "LastFish", "unMportant", "Deurpyn", "Fatbeaver") : src.key])</span> says, <span class='message'>\"[msg]\"</span></span>"
 
-	for (var/mob/M in player_list)
-		if (istype(M, /mob/new_player))
+	for(var/mob/M in player_list)
+		if(istype(M, /mob/new_player))
 			continue
 
 		if(M.client && M.client.holder && (M.client.prefs.toggles_chat & CHAT_DEAD)) // show the message to admins who have deadchat toggled on

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -7,7 +7,9 @@
 		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
-	if(!msg)	return
+
+	if(!msg)	
+		return
 
 	if(usr.client)
 		if(usr.client.prefs.muted & MUTE_PRAY)
@@ -22,12 +24,12 @@
 			liaison = 1
 
 	if(liaison)
-		msg = "\blue <b><font color=purple>LIAISON PRAY: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;ccmark=\ref[src]'>Mark</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;adminplayerfollow=\ref[src]'>FLW</a>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>):</b> [msg]"
+		msg = "\blue <b><font color=purple>LIAISON PRAY: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;pmark=\ref[src]'>Mark</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;adminplayerfollow=\ref[src]'>FLW</a>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>):</b> [msg]"
 	else
-		msg = "\blue <b><font color=purple>PRAY: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;mark=\ref[src]'>Mark</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;adminplayerfollow=\ref[src]'>FLW</a>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>):</b> [msg]"
+		msg = "\blue <b><font color=purple>PRAY: </font>[key_name(src, 1)] (<A HREF='?_src_=holder;pmark=\ref[src]'>Mark</A>) (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[src]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[src]'>JMP</A>) (<A HREF='?_src_=holder;adminplayerfollow=\ref[src]'>FLW</a>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;adminspawncookie=\ref[src]'>SC</a>):</b> [msg]"
 
 	for(var/client/C in admins)
-		if(C.prefs.toggles_chat & CHAT_PRAYER)
+		if((C.prefs.toggles_chat & CHAT_PRAYER) && ((R_ADMIN|R_MOD) & C.holder.rights))
 			to_chat(C, msg)
 	if(liaison)
 		to_chat(usr, "Your corporate overlords at Weyland-Yutani have received your message.")
@@ -49,5 +51,6 @@
 	var/msg = copytext(sanitize(text), 1, MAX_MESSAGE_LEN)
 	msg = "\blue <b><font color=crimson>SYNDICATE:</font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;mark=\ref[Sender]'>Mark</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=\ref[Sender]'>JMP</A>) (<A HREF='?_src_=holder;adminplayerfollow=\ref[Sender]'>FLW</a>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;SyndicateReply=\ref[Sender]'>RPLY</A>):</b> [msg]"
 	for(var/client/C in admins)
-		if(R_ADMIN & C.holder.rights)
+		if((R_ADMIN|R_MOD) & C.holder.rights)
 			to_chat(C, msg)
+			C << 'sound/effects/sos-morse-code.ogg'

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -5,6 +5,9 @@
 	var/datum/admins/holder = null
 	var/buildmode		= 0
 
+	var/adminhelp_marked = 0
+	var/mentorhelp_marked = 0 
+
 	var/last_message	= "" //Contains the last message sent by this client - used to protect against copy-paste spamming.
 	var/last_message_count = 0 //contins a number of how many times a message identical to last_message was sent.
 		/////////
@@ -20,6 +23,7 @@
 
 	var/donator = 0
 	var/adminhelped = 0
+	var/mentorhelped = 0
 
 	var/obj/screen/click_catcher/void
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -8,8 +8,6 @@
 	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak
 	var/obj/screen/hands = null //robot
 
-	var/adminhelp_marked = 0 // Prevents marking an Adminhelp more than once. Making this a client define will cause runtimes and break some Adminhelps
-
 	/*A bunch of this stuff really needs to go under their own defines instead of being globally attached to mob.
 	A variable should only be globally attached to turfs/objects/whatever, when it is in fact needed as such.
 	The current method unnecessarily clusters up the variable list, especially for humans (although rearranging won't really clean it up a lot but the difference will be noticable for other mobs).

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -77,3 +77,4 @@ virtualjohn - Admin
 wjohnston - Admin
 wubli - Admin
 wilchen - Admin
+lakiller8 - Admin


### PR DESCRIPTION
-Completes the separation of the ahelp and mhelp systems
-Removes possible metainformation wherever possible for mentors
-Removes toggle sleep, dsay, player notes list and show, USCM faxes, and the admin version of PMs/PM panel
-Adds mentor PM and mentor PM version of the panel