### PR TITLE
Scout Specialist Overhaul

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -158,3 +158,20 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 #define SENTRY_ALERT_BATTERY			5
 #define SENTRY_ALERT_DELAY				200 //20 seconds
 #define SENTRY_DAMAGE_ALERT_DELAY		50 //5 seconds
+
+
+//Scout cloak defines
+#define SCOUT_CLOAK_ENERGY	100
+#define SCOUT_CLOAK_STEALTH_DELAY 30
+#define SCOUT_CLOAK_RUN_DRAIN	5
+#define SCOUT_CLOAK_WALK_DRAIN	1
+#define SCOUT_CLOAK_ACTIVE_RECOVERY -5 //You only get this once every obj tick, so it'll be comparable to the inactive value
+#define SCOUT_CLOAK_INACTIVE_RECOVERY 5
+#define SCOUT_CLOAK_COOLDOWN 100
+#define SCOUT_CLOAK_TIMER 50
+#define SCOUT_CLOAK_RUN_ALPHA 128
+#define SCOUT_CLOAK_WALK_ALPHA 51
+#define SCOUT_CLOAK_STILL_ALPHA 13
+#define SCOUT_CLOAK_MAX_ENERGY 100
+#define SCOUT_CLOAK_OFF_DAMAGE 1
+#define SCOUT_CLOAK_OFF_ATTACK 2

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -84,5 +84,6 @@
 		var/hit = H.attacked_by(src, user, def_zone)
 		if (hit && hitsound)
 			playsound(loc, hitsound, 25, 1)
+		H.camo_off_process(SCOUT_CLOAK_OFF_ATTACK)
 		return hit
 	return 1

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -267,6 +267,10 @@
 		src.thrower = null
 		src.throw_source = null
 
+	if(ishuman(thrower)) //Human specific procs
+		var/mob/living/carbon/human/H = thrower
+		H.camo_off_process(SCOUT_CLOAK_OFF_ATTACK)
+
 
 //Overlays
 /atom/movable/overlay

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -409,18 +409,7 @@
 	icon_state = "smock"
 	worn_accessible = TRUE
 
-#define SCOUT_CLOAK_ENERGY	100
-#define SCOUT_CLOAK_STEALTH_DELAY 3
-#define SCOUT_CLOAK_RUN_DRAIN	5
-#define SCOUT_CLOAK_WALK_DRAIN	1
-#define SCOUT_CLOAK_ACTIVE_RECOVERY -5
-#define SCOUT_CLOAK_INACTIVE_RECOVERY -10
-#define SCOUT_CLOAK_COOLDOWN 100
-#define SCOUT_CLOAK_TIMER 50
-#define SCOUT_CLOAK_RUN_ALPHA 128
-#define SCOUT_CLOAK_WALK_ALPHA 205
-#define SCOUT_CLOAK_STILL_ALPHA 243
-#define SCOUT_CLOAK_MAX_ENERGY 100
+
 // Scout Cloak
 /obj/item/storage/backpack/marine/satchel/scout_cloak
 	name = "\improper M68 Thermal Cloak"
@@ -432,22 +421,31 @@
 	var/camo_active_timer = 0
 	var/camo_cooldown_timer = null
 	var/camo_last_stealth = null
+	var/camo_last_shimmer = null
 	var/camo_energy = 100
+	var/mob/living/wearer = null
+	actions_types = list(/datum/action/item_action/toggle)
 
 /obj/item/storage/backpack/marine/satchel/scout_cloak/Dispose()
+	camo_off()
+	wearer = null
 	processing_objects.Remove(src)
 	. = ..()
 
 /obj/item/storage/backpack/marine/satchel/scout_cloak/dropped(mob/user)
 	camo_off(user)
+	wearer = null
 	processing_objects.Remove(src)
 	. = ..()
 
-/obj/item/storage/backpack/marine/satchel/scout_cloak/verb/camouflage()
+/obj/item/storage/backpack/marine/satchel/scout_cloak/verb/use_camouflage()
 	set name = "Toggle M68 Thermal Camouflage"
 	set desc = "Activate your cloak's camouflage."
 	set category = "Scout"
 
+	camouflage()
+
+/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/camouflage()
 	if (!usr || usr.is_mob_incapacitated(TRUE))
 		return
 
@@ -473,12 +471,13 @@
 	camo_active = 1
 	camo_last_stealth = world.time
 	to_chat(M, "<span class='notice'>You activate your cloak's camouflage.</span>")
+	wearer = M
 
 	for (var/mob/O in oviewers(M))
 		O.show_message("[M] fades into thin air!", 1)
 	playsound(M.loc,'sound/effects/cloak_scout_on.ogg', 15, 1)
 
-	M.alpha = 10
+	M.alpha = SCOUT_CLOAK_STILL_ALPHA
 
 	if (M.smokecloaked)
 		M.smokecloaked = FALSE
@@ -515,43 +514,60 @@
 	spawn(1)
 		anim(user.loc,user,'icons/mob/mob.dmi',,"uncloak",,user.dir)
 
-	var/cooldown = round(camo_energy / max(1,SCOUT_CLOAK_INACTIVE_RECOVERY))
+	var/cooldown = round( (SCOUT_CLOAK_MAX_ENERGY - camo_energy) / SCOUT_CLOAK_INACTIVE_RECOVERY * 10) //Should be 20 seconds after a full depletion with inactive recovery at 5
 	camo_cooldown_timer = world.time + cooldown //recalibration and recharge time scales inversely with charge remaining
 	to_chat(user, "<span class='warning'>Your thermal cloak is recalibrating! It will be ready in [(camo_cooldown_timer - world.time) * 0.1] seconds.")
 	process_camo_cooldown(user, cooldown)
 	processing_objects.Remove(src)
 
-/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/process_camo_cooldown(mob/user, cooldown)
+/obj/item/storage/backpack/marine/satchel/scout_cloak/proc/process_camo_cooldown(mob/living/user, cooldown)
 	spawn(cooldown)
 		camo_cooldown_timer = null
-		to_chat(src, "<span class='danger'>Your thermal cloak has recalibrated and is ready to cloak again.</span>")
+		camo_energy = SCOUT_CLOAK_MAX_ENERGY
+		to_chat(user, "<span class='danger'>Your thermal cloak has recalibrated and is ready to cloak again.</span>")
+
+/obj/item/storage/backpack/marine/satchel/scout_cloak/examine(mob/user)
+	. = ..()
+	var/list/details = list()
+	details +=("It has [camo_energy]/[SCOUT_CLOAK_MAX_ENERGY] charge.</br>")
+
+	details +=("Its safeties are on.</br>")
+
+	if(camo_active)
+		details +=("It's currently active.</br>")
+
+	to_chat(user, "<span class='warning'>[details.Join(" ")]</span>")
+
+/obj/item/storage/backpack/marine/satchel/scout_cloak/item_action_slot_check(mob/user, slot)
+	if(!ishuman(user))
+		return FALSE
+	if(slot != WEAR_BACK)
+		return FALSE
+	return TRUE //only give action button when armor is worn.
+
+
+/obj/item/storage/backpack/marine/satchel/scout_cloak/attack_self(mob/user)
+	. = ..()
+	camouflage()
 
 /obj/item/storage/backpack/marine/satchel/scout_cloak/proc/camo_adjust_energy(mob/user, drain = SCOUT_CLOAK_WALK_DRAIN)
 	camo_energy = CLAMP(camo_energy - drain,0,SCOUT_CLOAK_MAX_ENERGY)
 
 	if(!camo_energy) //Turn off the camo if we run out of energy.
-		to_chat(src, "<span class='danger'>Your thermal cloak lacks sufficient energy to remain camouflaged.</span>")
+		to_chat(user, "<span class='danger'>Your thermal cloak lacks sufficient energy to remain active.</span>")
 		camo_off(user)
 
-/obj/item/storage/backpack/marine/satchel/scout_cloak/process(mob/user)
-	//if(!camo_active) //Recharge if the cloak is off and not at full charge
-	//	if(camo_energy < SCOUT_CLOAK_MAX_ENERGY )
-	//		camo_adjust_energy(src, SCOUT_CLOAK_INACTIVE_RECOVERY)
-	//		if(camo_energy >= SCOUT_CLOAK_MAX_ENERGY)
-	//			to_chat(user, "<span class='danger'>Your thermal cloak is fully recharged.</span>")
-	//		return
-	if(camo_last_stealth > world.time - SCOUT_CLOAK_STEALTH_DELAY) //We don't start out at max invisibility
-		alpha = HUNTER_STEALTH_RUN_ALPHA //50% invisible
+/obj/item/storage/backpack/marine/satchel/scout_cloak/process()
+
+	if(camo_last_shimmer > world.time - SCOUT_CLOAK_STEALTH_DELAY) //Shimmer after taking aggressive actions; no energy regeneration
+		alpha = SCOUT_CLOAK_RUN_ALPHA //50% invisible
+	else if(camo_last_stealth > (world.time - SCOUT_CLOAK_STEALTH_DELAY) ) //We have an initial reprieve at max invisibility allowing us to reposition; no energy recovery during this time
+		wearer.alpha = SCOUT_CLOAK_STILL_ALPHA
 		return
 	//Stationary stealth
-	else if(user.last_move_intent < world.time - SCOUT_CLOAK_STEALTH_DELAY) //If we're standing still for 3 seconds we become almost completely invisible
-		alpha = SCOUT_CLOAK_STILL_ALPHA //95% invisible
-		camo_adjust_energy(src, SCOUT_CLOAK_ACTIVE_RECOVERY)
-
-	if(!camo_energy) //Turn off the camo if we run out of energy.
-		to_chat(user, "<span class='danger'>Your thermal cloak lacks sufficient energy to remain camouflaged.</span>")
-		camo_off(user)
-
+	else if((camo_last_shimmer && wearer.last_move_intent) < (world.time - SCOUT_CLOAK_STEALTH_DELAY) ) //If we're standing still and haven't shimmed in the past 3 seconds we become almost completely invisible
+		wearer.alpha = SCOUT_CLOAK_STILL_ALPHA //95% invisible
+		camo_adjust_energy(wearer, SCOUT_CLOAK_ACTIVE_RECOVERY)
 
 // Welder Backpacks //
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -261,6 +261,12 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 	var/datum/limb/picked = pick(parts)
 	if(picked.take_damage(brute,burn,sharp,edge))
 		UpdateDamageIcon()
+
+	if(brute)
+		camo_off_process(SCOUT_CLOAK_OFF_DAMAGE, brute) //If we have the Scout cloak, check for a short out
+	if(burn)
+		camo_off_process(SCOUT_CLOAK_OFF_DAMAGE, burn) //If we have the Scout cloak, check for a short out
+
 	updatehealth()
 	speech_problem_flag = 1
 
@@ -321,6 +327,12 @@ In most cases it makes more sense to use apply_damage() instead! And make sure t
 		burn	-= (picked.burn_dam - burn_was)
 
 		parts -= picked
+
+	if(brute)
+		camo_off_process(SCOUT_CLOAK_OFF_DAMAGE, brute) //If we have the Scout cloak, check for a short out
+	if(burn)
+		camo_off_process(SCOUT_CLOAK_OFF_DAMAGE, burn) //If we have the Scout cloak, check for a short out
+
 	updatehealth()
 	if(update)	UpdateDamageIcon()
 
@@ -410,5 +422,8 @@ This function restores all limbs.
 				UpdateDamageIcon()
 
 	// Will set our damageoverlay icon to the next level, which will then be set back to the normal level the next mob.Life().
+
+	camo_off_process(SCOUT_CLOAK_OFF_DAMAGE, damage) //If we have the Scout cloak, check for a short out
+
 	updatehealth()
 	return 1

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -291,3 +291,30 @@
 			prot["head"] = max(1 - I.permeability_coefficient, prot["head"])
 	var/protection = (prot["head"] + prot["arms"] + prot["feet"] + prot["legs"] + prot["groin"] + prot["chest"] + prot["hands"])/7
 	return protection
+
+/mob/living/carbon/human/throw_at(atom/target, range, speed, thrower)
+	. = ..()
+	camo_off_process(SCOUT_CLOAK_OFF_ATTACK)
+
+/mob/living/proc/camo_off_process(code = 0, damage = 0)
+	return
+
+/mob/living/carbon/human/camo_off_process(code = 0, damage = 0)
+	to_chat(src, "<span class='danger'>CAMO OFF PROCESS DEBUG: Code: [code] Damage: [damage] User: [src]</span>")
+	if(!src)
+		return
+	if(!code)
+		return
+	if(!istype(back, /obj/item/storage/backpack/marine/satchel/scout_cloak) )
+		return
+	var/obj/item/storage/backpack/marine/satchel/scout_cloak/S = back
+	switch(code)
+		if(SCOUT_CLOAK_OFF_ATTACK)
+			to_chat(src, "<span class='danger'>Your cloak shimmers from your actions!</span>")
+			S.camo_last_shimmer = world.time //Reduces transparency to 50%
+			alpha = SCOUT_CLOAK_RUN_ALPHA
+		if(SCOUT_CLOAK_OFF_DAMAGE)
+			if(damage >= 15)
+				to_chat(src, "<span class='danger'>Your cloak shimmers from the damage!</span>")
+				S.camo_last_shimmer = world.time //Reduces transparency to 50%
+				alpha = SCOUT_CLOAK_RUN_ALPHA

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -78,33 +78,31 @@
 	if(mRun in mutations)
 		. = 0
 
-	Process_Cloaking()
+	Process_Cloaking(src)
 
 	. += config.human_delay
 
 
-/mob/living/carbon/human/proc/Process_Cloaking()
+/mob/living/proc/Process_Cloaking(mob/living/carbon/human/user)
 	if(!istype(back, /obj/item/storage/backpack/marine/satchel/scout_cloak) )
 		return
 	var/obj/item/storage/backpack/marine/satchel/scout_cloak/S = back
 	if(!S.camo_active)
 		return
-	if(S.camo_last_stealth > world.time - SCOUT_CLOAK_STEALTH_DELAY) //We don't start out at max invisibility
-		alpha = HUNTER_STEALTH_RUN_ALPHA //50% invisible
-		return
-	//Stationary stealth
-	else if(last_move_intent < world.time - SCOUT_CLOAK_STEALTH_DELAY) //If we're standing still for 3 seconds we become almost completely invisible
+	if(S.camo_last_shimmer > world.time - SCOUT_CLOAK_STEALTH_DELAY) //Shimmer after taking aggressive actions
+		alpha = SCOUT_CLOAK_RUN_ALPHA //50% invisible
+		S.camo_adjust_energy(src, SCOUT_CLOAK_RUN_DRAIN)
+	else if(S.camo_last_stealth > world.time - SCOUT_CLOAK_STEALTH_DELAY) //We have an initial reprieve at max invisibility allowing us to reposition, albeit at a high drain rate
 		alpha = SCOUT_CLOAK_STILL_ALPHA //95% invisible
+		S.camo_adjust_energy(src, SCOUT_CLOAK_RUN_DRAIN)
 	//Walking stealth
 	else if(m_intent == MOVE_INTENT_WALK)
 		alpha = SCOUT_CLOAK_WALK_ALPHA //80% invisible
 		S.camo_adjust_energy(src, SCOUT_CLOAK_WALK_DRAIN)
-	//Running stealth
+	//Running and post-attack stealth
 	else
 		alpha = SCOUT_CLOAK_RUN_ALPHA //50% invisible
 		S.camo_adjust_energy(src, SCOUT_CLOAK_RUN_DRAIN)
-
-
 
 /mob/living/carbon/human/Process_Spacemove(var/check_drift = 0)
 	//Can we act

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -78,7 +78,32 @@
 	if(mRun in mutations)
 		. = 0
 
+	Process_Cloaking()
+
 	. += config.human_delay
+
+
+/mob/living/carbon/human/proc/Process_Cloaking()
+	if(!istype(back, /obj/item/storage/backpack/marine/satchel/scout_cloak) )
+		return
+	var/obj/item/storage/backpack/marine/satchel/scout_cloak/S = back
+	if(!S.camo_active)
+		return
+	if(S.camo_last_stealth > world.time - SCOUT_CLOAK_STEALTH_DELAY) //We don't start out at max invisibility
+		alpha = HUNTER_STEALTH_RUN_ALPHA //50% invisible
+		return
+	//Stationary stealth
+	else if(last_move_intent < world.time - SCOUT_CLOAK_STEALTH_DELAY) //If we're standing still for 3 seconds we become almost completely invisible
+		alpha = SCOUT_CLOAK_STILL_ALPHA //95% invisible
+	//Walking stealth
+	else if(m_intent == MOVE_INTENT_WALK)
+		alpha = SCOUT_CLOAK_WALK_ALPHA //80% invisible
+		S.camo_adjust_energy(src, SCOUT_CLOAK_WALK_DRAIN)
+	//Running stealth
+	else
+		alpha = SCOUT_CLOAK_RUN_ALPHA //50% invisible
+		S.camo_adjust_energy(src, SCOUT_CLOAK_RUN_DRAIN)
+
 
 
 /mob/living/carbon/human/Process_Spacemove(var/check_drift = 0)

--- a/code/modules/projectiles/updated_projectiles/gun_system.dm
+++ b/code/modules/projectiles/updated_projectiles/gun_system.dm
@@ -572,6 +572,7 @@ and you're good to go.
 				active_attachable.activate_attachment(src, null, TRUE)
 			else
 				active_attachable.fire_attachment(target,src,user) //Fire it.
+				user.camo_off_process(SCOUT_CLOAK_OFF_ATTACK) //Cause cloak to shimmer.
 				last_fired = world.time
 			return
 			//If there's more to the attachment, it will be processed farther down, through in_chamber and regular bullet act.
@@ -684,6 +685,8 @@ and you're good to go.
 		if(i < bullets_fired) // We still have some bullets to fire.
 			extra_delay = min(extra_delay+(burst_delay*2), fire_delay*3) // The more bullets you shoot, the more delay there is, but no more than thrice the regular delay.
 			sleep(burst_delay)
+
+		user.camo_off_process(SCOUT_CLOAK_OFF_ATTACK) //Cause cloak to shimmer.
 
 	flags_gun_features &= ~GUN_BURST_FIRING // We always want to turn off bursting when we're done.
 

--- a/code/modules/projectiles/updated_projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/specialist.dm
@@ -153,11 +153,17 @@
 	current_mag = /obj/item/ammo_magazine/rifle/m4ra
 	force = 16
 	attachable_allowed = list(
+						/obj/item/attachable/heavy_barrel,
+						/obj/item/attachable/extended_barrel,
 						/obj/item/attachable/suppressor,
 						/obj/item/attachable/verticalgrip,
 						/obj/item/attachable/angledgrip,
 						/obj/item/attachable/bipod,
-						/obj/item/attachable/compensator)
+						/obj/item/attachable/compensator,
+						/obj/item/attachable/lasersight,
+						/obj/item/attachable/attached_gun/grenade,
+						/obj/item/attachable/attached_gun/shotgun,
+						)
 
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_SPECIALIST|GUN_WIELDED_FIRING_ONLY
 	gun_skill_category = GUN_SKILL_SPEC
@@ -179,11 +185,14 @@
 /obj/item/weapon/gun/rifle/m4ra/set_gun_config_values()
 	fire_delay = config.high_fire_delay
 	burst_amount = config.med_burst_value
-	burst_delay = config.mlow_fire_delay
-	accuracy_mult = config.base_hit_accuracy_mult
-	scatter = config.low_scatter_value
+	burst_delay = config.vlow_fire_delay
+	accuracy_mult = config.base_hit_accuracy_mult + config.low_hit_accuracy_mult
+	accuracy_mult_unwielded = config.base_hit_accuracy_mult - config.max_hit_accuracy_mult
+	scatter_unwielded = config.max_scatter_value
 	damage_mult = config.base_hit_damage_mult
 	recoil = config.min_recoil_value
+	recoil_unwielded = config.high_recoil_value
+	damage_falloff_mult = config.low_damage_falloff_mult
 
 //-------------------------------------------------------
 //SMARTGUN


### PR DESCRIPTION
-The thermal cape's cloaking now features a depleteable energy counter instead of a  fixed duration; when energy reaches 0, the cloaking ends.

-Cloaking initially grants 95% transparency for a short duration. This transparency is reduced to 80% while walking after a short delay, or 50% while running. Remaining still for 3 seconds will increase the transparency to 95%. 

-Energy is consumed at a rate of 1 per tile walked, and 5 per tile ran. Energy is slowly restored at a rate of 5 once every every 2 seconds roughly while stationary.

-Most aggressive actions like melee attacks, throwing and shooting will cause the Cloak to 'shimmer' capping transparency at 50% for a short duration. While shimmering, energy consumption for movement is maximized.

-M4RA rifle substantially improved; it now has more accuracy, less scatter, a slightly faster burst and can equip many more attachments like the barrel charger, extended barrel, laser sight, underslung shotgun and flamer.