### PR TITLE
Changes ladder adjacency check

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -65,7 +65,7 @@
 	return attack_hand(M)
 
 /obj/structure/ladder/attack_hand(mob/user)
-	if(user.is_mob_incapacitated() || Adjacent(user) || user.lying || user.buckled || user.anchored)
+	if(user.is_mob_incapacitated() || !Adjacent(user) || user.lying || user.buckled || user.anchored)
 		return
 	var/ladder_dir_name
 	var/obj/structure/ladder/ladder_dest


### PR DESCRIPTION
#637 introduced new behaviour, changing `get_dist(user, src) > 1` to `Adjacent(user)`

Unless I'm mistaken, adjacent() asks if the argument is adjacent, which should make my diagnosis obvious: you can't use the ladder if you're adjacent, the opposite of previous behaviour (distance >= 1 means you can't use the ladder).

I assume just slapping a ! not in front will fix this.