### PR TITLE
Fire Tweaks

### DIFF
--- a/code/game/objects/items/explosives/grenades/marines.dm
+++ b/code/game/objects/items/explosives/grenades/marines.dm
@@ -126,21 +126,11 @@ proc/flame_radius(radius = 1, turf/T, burn_intensity = 25, burn_duration = 25, b
 	radius = CLAMP(radius, 1, 7) //Sterilize inputs
 	int_var = CLAMP(int_var, 0.1,0.5)
 	dur_var = CLAMP(int_var, 0.1,0.5)
+	fire_stacks = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
+	burn_damage = rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) ) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var) )
 	for(var/obj/flamer_fire/F in range(radius,T)) // No stacking flames!
 		cdel(F)
-	new /obj/flamer_fire(T, rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, radius) //Gaussian.
-	for(var/mob/living/carbon/M in range(radius, T))
-		if(isXeno(M))
-			var/mob/living/carbon/Xenomorph/X = M
-			if(X.fire_immune)
-				continue
-		if(M.stat == DEAD)
-			continue
-		var/dist = get_dist(T,M)
-		M.adjustFireLoss(rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var)) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var))*min(1,(1-(dist-1)/radius)))//Gaussian
-		M.adjust_fire_stacks(rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var)) + rand(burn_damage*(0.5-int_var),burn_damage*(0.5+int_var))*min(1,(1-(dist-1)/radius)))//Gaussian
-		M.IgniteMob()
-		M.visible_message("<span class='danger'>[M] bursts into flames!</span>","[isXeno(M)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
+	new /obj/flamer_fire(T, rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)) + rand(burn_intensity*(0.5-int_var), burn_intensity*(0.5+int_var)), rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)) + rand(burn_duration*(0.5-int_var), burn_duration*(0.5-int_var)), colour, radius, burn_damage, fire_stacks) //Gaussian.
 
 /obj/item/explosive/grenade/incendiary/molotov
 	name = "\improper improvised firebomb"

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -39,8 +39,7 @@
 	var/armor_deflection = 0 //Chance of deflecting projectiles.
 	var/armor_bonus = 0 //Extra chance of deflecting projectiles due to temporary effects
 	var/armor_pheromone_bonus = 0 //
-	var/fire_immune = 0 //Boolean
-	var/fire_resist = 1 //0 to 1; lower is better as it is a multiplier.
+
 	var/obj/structure/tunnel/start_dig = null
 	var/tunnel_delay = 0
 	var/datum/ammo/xeno/ammo = null //The ammo datum for our spit projectiles. We're born with this, it changes sometimes.

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -80,5 +80,5 @@
 
 	var/no_stun = 0
 
-	var/fire_immune = 0 //Boolean
+	var/fire_immune = FALSE
 	var/fire_resist = 1 //0 to 1; lower is better as it is a multiplier.

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -79,3 +79,6 @@
 	var/canEnterVentWith = "/obj/item/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0&/obj/item/verbs=0" // Vent crawling whitelisted items, whoo
 
 	var/no_stun = 0
+
+	var/fire_immune = 0 //Boolean
+	var/fire_resist = 1 //0 to 1; lower is better as it is a multiplier.

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -78,7 +78,7 @@
 
 	var/canEnterVentWith = "/obj/item/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0&/obj/item/verbs=0" // Vent crawling whitelisted items, whoo
 
-	var/no_stun = 0
+	var/no_stun = FALSE
 
 	var/fire_immune = FALSE
 	var/fire_resist = 1 //0 to 1; lower is better as it is a multiplier.

--- a/code/modules/projectiles/updated_projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/updated_projectiles/ammo_datums.dm
@@ -964,10 +964,8 @@
 		return
 	smoke.set_up(1, T)
 	smoke.start()
-	for(var/obj/flamer_fire/F in range(radius,T)) // No stacking flames!
-		cdel(F)
 	playsound(T, 'sound/weapons/gun_flamethrower2.ogg', 50, 1, 4)
-	flame_radius(radius, 25, 25, 25, 15)
+	flame_radius(radius, T, 25, 25, 25, 15)
 
 
 /datum/ammo/rocket/wp/on_hit_mob(mob/M,obj/item/projectile/P)

--- a/code/modules/projectiles/updated_projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/flamer.dm
@@ -429,8 +429,6 @@
 		burnlevel = burn_lvl
 	processing_objects.Add(src)
 
-	to_chat(world, "DEBUG: Flamer Fire: fire_stacks: [fire_stacks], fire_damage: [fire_damage]")
-
 	if(fire_spread_amount > 0)
 		var/turf/T
 		for(var/dirn in cardinal)

--- a/code/modules/projectiles/updated_projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/updated_projectiles/guns/flamer.dm
@@ -236,9 +236,17 @@
 			if(istype(H.wear_suit, /obj/item/clothing/suit/fire) || (istype(H.wear_suit, /obj/item/clothing/suit/storage/marine/M35) && istype(H.head, /obj/item/clothing/head/helmet/marine/pyro)))
 				continue
 
+		var/armor_block = M.run_armor_check(null, "energy")
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(istype(H.wear_suit, /obj/item/clothing/suit/fire) || (istype(H.wear_suit, /obj/item/clothing/suit/storage/marine/M35) && istype(H.head, /obj/item/clothing/head/helmet/marine/pyro)))
+				H.show_message(text("Your suit protects you from the flames."),1)
+				armor_block = CLAMP(armor_block * 1.5, 0.75, 1) //Min 75% resist, max 100%
+		M.apply_damage(rand(burn,(burn*2))* fire_mod, BURN, null, armor_block) // Make it so its the amount of heat or twice it for the initial blast.
+
 		M.adjust_fire_stacks(rand(5,burn*2))
 		M.IgniteMob()
-		M.adjustFireLoss(rand(burn,(burn*2))* fire_mod)  // Make it so its the amount of heat or twice it for the initial blast.
+
 		to_chat(M, "[isXeno(M)?"<span class='xenodanger'>":"<span class='highdanger'>"]Augh! You are roasted by the flames!")
 
 /obj/item/weapon/gun/flamer/proc/triangular_flame(var/atom/target, var/mob/living/user, var/burntime, var/burnlevel)
@@ -409,7 +417,7 @@
 	var/burnlevel = 10 //Tracks how HOT the fire is. This is basically the heat level of the fire and determines the temperature.
 	var/flame_color = "red"
 
-/obj/flamer_fire/New(loc, fire_lvl, burn_lvl, f_color, fire_spread_amount)
+/obj/flamer_fire/New(loc, fire_lvl, burn_lvl, f_color, fire_spread_amount, fire_stacks = 0, fire_damage = 0)
 	..()
 	if (f_color)
 		flame_color = f_color
@@ -421,14 +429,17 @@
 		burnlevel = burn_lvl
 	processing_objects.Add(src)
 
+	to_chat(world, "DEBUG: Flamer Fire: fire_stacks: [fire_stacks], fire_damage: [fire_damage]")
+
 	if(fire_spread_amount > 0)
 		var/turf/T
 		for(var/dirn in cardinal)
 			T = get_step(loc, dirn)
 			if(istype(T,/turf/open/space))
 				continue
-			if(locate(/obj/flamer_fire) in T)
-				continue //No stacking
+			var/obj/flamer_fire/F
+			if(locate(F) in T)
+				cdel(F) //No stacking
 			var/new_spread_amt = T.density ? 0 : fire_spread_amount - 1 //walls stop the spread
 			if(new_spread_amt)
 				for(var/obj/O in T)
@@ -436,7 +447,18 @@
 						new_spread_amt = 0
 						break
 			spawn(0) //delay so the newer flame don't block the spread of older flames
-				new /obj/flamer_fire(T, fire_lvl, burn_lvl, f_color, new_spread_amt)
+				new /obj/flamer_fire(T, fire_lvl, burn_lvl, f_color, new_spread_amt, fire_stacks, fire_damage)
+				var/mob/living/C
+				if(fire_stacks || fire_damage)
+					for(C in T)
+						if(C.fire_immune)
+							continue
+						else
+							C.adjust_fire_stacks(fire_stacks)
+							var/armor_block = C.run_armor_check("chest", "energy")
+							C.apply_damage(fire_damage, BURN, null, armor_block)
+							C.IgniteMob()
+							C.visible_message("<span class='danger'>[C] bursts into flames!</span>","[isXeno(C)?"<span class='xenodanger'>":"<span class='highdanger'>"]You burst into flames!</span>")
 
 
 /obj/flamer_fire/Dispose()
@@ -448,17 +470,6 @@
 /obj/flamer_fire/Crossed(mob/living/M) //Only way to get it to reliable do it when you walk into it.
 	if(istype(M))
 		var/fire_mod = 1
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			if(isXeno(H.pulledby))
-				var/mob/living/carbon/Xenomorph/Z = H.pulledby
-				if(!Z.fire_immune)
-					Z.adjust_fire_stacks(burnlevel)
-					Z.IgniteMob()
-			if(istype(H.wear_suit, /obj/item/clothing/suit/fire) || (istype(H.wear_suit, /obj/item/clothing/suit/storage/marine/M35) && istype(H.head, /obj/item/clothing/head/helmet/marine/pyro)))
-				H.show_message(text("Your suit protects you from the flames."),1)
-				H.adjustFireLoss(burnlevel*0.25) //Does small burn damage to a person wearing one of the suits.
-				return
 		if(isXeno(M))
 			var/mob/living/carbon/Xenomorph/X = M
 			if(X.fire_immune)
@@ -468,7 +479,19 @@
 		if (prob(firelevel + 2*M.fire_stacks)) //the more soaked in fire you are, the likelier to be ignited
 			M.IgniteMob()
 
-		M.adjustFireLoss(round(burnlevel*0.5)* fire_mod) //This makes fire stronk.
+		var/armor_block = M.run_armor_check(null, "energy")
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(isXeno(H.pulledby))
+				var/mob/living/carbon/Xenomorph/Z = H.pulledby
+				if(!Z.fire_immune)
+					Z.adjust_fire_stacks(burnlevel)
+					Z.IgniteMob()
+			if(istype(H.wear_suit, /obj/item/clothing/suit/fire) || (istype(H.wear_suit, /obj/item/clothing/suit/storage/marine/M35) && istype(H.head, /obj/item/clothing/head/helmet/marine/pyro)))
+				H.show_message(text("Your suit protects you from the flames."),1)
+				armor_block = CLAMP(armor_block * 1.5, 0.75, 1) //Min 75% resist, max 100%
+		M.apply_damage(round(burnlevel*0.5)* fire_mod, BURN, null, armor_block)
+
 		to_chat(M, "<span class='danger'>You are burned!</span>")
 		if(isXeno(M))
 			M.updatehealth()
@@ -529,6 +552,8 @@
 					if(rand(1,100) < 70)
 						X.emote("roar")
 				continue
+
+
 			I.adjust_fire_stacks(burnlevel) //If i stand in the fire i deserve all of this. Also Napalm stacks quickly.
 			if(prob(firelevel))
 				I.IgniteMob()


### PR DESCRIPTION
-AoE flame munitions like the Mortar, incendiary grenade and WP rocket now apply initial damage/ignition effects vs targets caught in the actual flames they produce instead of simple radii.

-Armour now applies to more instances of fire damage, using the 'energy' resistance.

-Consolidated functions like clearing old flames to allow for new ones.

-WP rocket works as intended.